### PR TITLE
Handle text/csv content type for measurements.

### DIFF
--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -43,8 +43,8 @@
   <logger name="org.eclipse.jetty" level="INFO" />
   <logger name="org.quartz.core.QuartzSchedulerThread" level="INFO" />
 
-  <!-- log all CQL -->
-  <logger name="kixi.hecuba.storage.db.CQL" level="DEBUG"/>
+  <!-- log all CQL-->
+  <logger name="kixi.hecuba.storage.db.CQL" level="INFO"/>
 
   <logger name="user" level="ALL" />
   <logger name="application" level="ALL" />

--- a/src/kixi/hecuba/webutil.clj
+++ b/src/kixi/hecuba/webutil.clj
@@ -14,7 +14,8 @@
    [clj-time.periodic :as tp]
    [clojure.pprint :refer (pprint)]
    [clojure.walk :refer (postwalk)]
-   [liberator.core :as liberator]))
+   [liberator.core :as liberator]
+   [clojure.data.csv :as csv]))
 
 (defprotocol Body
   (read-edn-body [body])
@@ -95,6 +96,12 @@
 
 (defmethod render-items "application/json" [_ items]
   (map encode items))
+
+(defmethod render-items "text/csv" [_ items]
+  (let [headers (into [] (map name (keys (first items))))]
+    (with-out-str
+      (csv/write-csv *out* [headers] :newline :cr+lf :separator \,)
+      (csv/write-csv *out* (map vals items) :newline :cr+lf :separator \,))))
 
 (defmulti render-item :content-type :default :unknown)
 (defmethod render-item :unknown [_ item]


### PR DESCRIPTION
The reason for using case on (:content-type request) is that render-items function in webutil.clj is very generic, and measurements need a little extra work depending on the content type (which is specific to them only).
