### PR TITLE
Add user_metadata to sensor table.

### DIFF
--- a/cql/hecuba-schema.cql
+++ b/cql/hecuba-schema.cql
@@ -402,6 +402,7 @@ CREATE TABLE sensors (
   synthetic boolean,
   unit text,
   user_id text,
+  user_metadata map<text,text>,
   PRIMARY KEY (device_id, type)
 ) WITH
   bloom_filter_fp_chance=0.010000 AND


### PR DESCRIPTION
POST - inserts user_metadata alongside other data in body. If this entry already exists in the database, this will actually overwrite it (any existing user_metadata will be replaced with new user_metadata)
PUT - appends to user_metadata, so it's possible to overwrite some entires in existing user_metadata without deleting others.
