### PR TITLE
Don't allow the user to update internal data.

### DIFF
--- a/src/kixi/hecuba/data/devices.clj
+++ b/src/kixi/hecuba/data/devices.clj
@@ -7,37 +7,42 @@
             [kixi.hecuba.webutil :refer (stringify-values)]
             [cheshire.core :as json]))
 
+(def user-editable-keys [:id :description :entity_id 
+                        :location :metadata :metering_point_id
+                        :name :parent_id :privacy])
+
 (defn parse-device [device session]
   (let [device_id (:id device)
         sensors   (sensors/->clojure device_id session)]
     (-> device
-        (assoc :readings sensors)
         (parse-item :metadata)
-        (assoc :device_id device_id)
+        (assoc :device_id device_id :readings sensors)
         (dissoc :id))))
 
 (defn encode [device]
   (-> device
-      (dissoc :readings :device_id)
+      (select-keys user-editable-keys)
       (update-in [:location] json/encode)
       (update-in [:metadata] json/encode)
       stringify-values))
 
 (defn insert [session entity_id device]
-  (let [id (:id device)]
+  (let [id             (:id device)
+        encoded-device (encode device)]
     (db/execute session (hayt/insert :devices
-                                     (hayt/values (encode device))))
+                                     (hayt/values encoded-device)))
     (db/execute session (hayt/update :entities
-                                     (hayt/set-columns {:devices [+ {id (str device)}]})
+                                     (hayt/set-columns {:devices [+ {id (str encoded-device)}]})
                                      (hayt/where [[= :id entity_id]])))))
 
 (defn update [session entity_id id device]
-  (db/execute session (hayt/update :devices
-                                   (hayt/set-columns (encode device))
-                                   (hayt/where [[= :id id]])))
-  (db/execute session (hayt/update :entities
-                                     (hayt/set-columns {:devices [+ {id (str device)}]})
-                                     (hayt/where [[= :id entity_id]]))))
+  (let [encoded-device (encode device)]
+    (db/execute session (hayt/update :devices
+                                     (hayt/set-columns encoded-device)
+                                     (hayt/where [[= :id id]])))
+    (db/execute session (hayt/update :entities
+                                     (hayt/set-columns {:devices [+ {id (str encoded-device)}]})
+                                     (hayt/where [[= :id entity_id]])))))
 
 (defn delete [session entity_id id]
   (let [response1 (db/execute session (hayt/delete :devices


### PR DESCRIPTION
Don't allow to insert/update columns other then the one listed in user-visible-keys.
GET still returns internal columns like median, actual_annual, etc. since we use it to display data on web UI.
