### PR TITLE
Fix up downloads URI and status handling.

### DIFF
--- a/src/kixi/hecuba/api/uploads.clj
+++ b/src/kixi/hecuba/api/uploads.clj
@@ -97,7 +97,7 @@
 (defn merge-status-with-metadata [store s3-key]
   (let [[src-name username uuid typ] (str/split s3-key #"/")
         {:keys [auth file-bucket]} (:s3 store)
-        metadata (aws/get-object-metadata auth file-bucket (str src-name "/" username "/" uuid "/data"))
+        metadata (aws/get-object-metadata auth file-bucket (str src-name "/" username "/" uuid "/data")) ;; FIXME this call to aws/get-object-metadata should be to a fn in kixipipe, passed an item map with uuid set to the generated string.
         {:keys [uploads-timestamp uploads-filename]} (:user metadata)]
     (hash-map :id uuid
               :filename uploads-filename

--- a/src/kixi/hecuba/controller/pipeline.clj
+++ b/src/kixi/hecuba/controller/pipeline.clj
@@ -30,8 +30,7 @@
         actual-annual-q         (new-queue {:name "actual-annual-q" :queue-size 50})
         store-upload-s3-q       (new-queue {:name "store-upload-s3-q" :queue-size 50})
         upload-measurements-q   (new-queue {:name "data-upload-q" :queue-size 10})
-        download-measurements-q (new-queue {:name "data-download-q" :queue-size 10})
-        ]
+        download-measurements-q (new-queue {:name "data-download-q" :queue-size 50 :number-of-consumer-threads 4})]
 
     (defnconsumer fanout-q [{:keys [dest type] :as item}]
       (let [item (dissoc item :dest)]

--- a/src/kixi/hecuba/data/measurements.clj
+++ b/src/kixi/hecuba/data/measurements.clj
@@ -70,11 +70,12 @@
 
 (defn- retrieve-measurements-for-months [session [month & more]  where]
   (log/info "Got month " month)
-  (lazy-cat (db/execute session
-                        (hayt/select :partitioned_measurements
-                                     (hayt/where (conj where [= :month month]))))
-            (when (seq more)
-              (retrieve-measurements-for-months session more where))))
+  (when month
+    (lazy-cat (db/execute session
+                          (hayt/select :partitioned_measurements
+                                       (hayt/where (conj where [= :month month]))))
+              (when (seq more)
+                (retrieve-measurements-for-months session more where)))))
 
 (defn retrieve-measurements
   "Iterate over a sequence of months and concatanate measurements retrieved from the database."

--- a/src/kixi/hecuba/data/measurements/core.clj
+++ b/src/kixi/hecuba/data/measurements/core.clj
@@ -34,6 +34,13 @@
                        "Sensor Range Max"
                        "Sensor Range Min"])
 
+(defn get-status [{:keys [s3]} item]
+  ;; TODO there should be a better way to do this in s3 ns.
+  (let [s3-key (s3/s3-key-from item )]
+    (when (s3/item-exists? s3 s3-key)
+      (with-open [in (s3/get-object-by-metadata s3 {:key s3-key})]
+        (:status (json/parse-string (slurp in)))))))
+
 (defn write-status [store item]
   (let [status-file (ioplus/mk-temp-file! "hecuba" ".tmp")]
     (try

--- a/src/kixi/hecuba/web_paths.clj
+++ b/src/kixi/hecuba/web_paths.clj
@@ -59,7 +59,9 @@
    :uploads-status-resource "uploads/%s/%s/status"
    :uploads-data-resource "uploads/%s/%s/data"
    :uploads-for-username "programme/%s/project/%s/uploads/username" ;; Used to display status. programme_id and  project_id used for allowed?
-   })
+
+   :downloads-status-resource "downloads/%s/%s/status"
+   :downloads-data-resource "downloads/%s/%s/data"})
 
 (defn compojure-route
   ([route keys]


### PR DESCRIPTION
This adds a pending status file ASAP after the request is accepted. It
also checks for the existence of such a file with status "PENDING"
before accepting another request for the same entity. If a request
exists it returns a 303 referring the caller to the in progress request.
