### PR TITLE
Delete hourly & daily rollups

### DIFF
--- a/src/kixi/hecuba/time.clj
+++ b/src/kixi/hecuba/time.clj
@@ -46,3 +46,7 @@
 (defn range->months [start-date end-date]
   (->> (time-range start-date end-date (t/months 1))
        (map #(get-month-partition-key (tc/to-date %)))))
+
+(defn range->years [start-date end-date]
+  (->> (time-range start-date end-date (t/years 1))
+       (map #(get-year-partition-key (tc/to-date-time %)))))


### PR DESCRIPTION
Otherwise we leave them hanging around when the underlying measurements
are gone and the rollups job won't actually tidy them up.
