### PR TITLE
Session & Security use prepared-statements.

### DIFF
--- a/src/kixi/hecuba/protocols.clj
+++ b/src/kixi/hecuba/protocols.clj
@@ -3,5 +3,7 @@
 
 (defprotocol Cassandra
   (-execute [session query opts])
+  (-prepare-statement [session statement])
+  (-execute-prepared [session query opts])
   (-execute-async [session query opts])
   (-execute-chan [session query opts]))

--- a/src/kixi/hecuba/session.clj
+++ b/src/kixi/hecuba/session.clj
@@ -7,33 +7,29 @@
    [clj-time.core :as t]
    [kixi.hecuba.storage.db :as db]))
 
-(deftype CassandraStore [store]
+(deftype CassandraStore [store read-session-cql write-session-cql]
   SessionStore
   (read-session [_ key]
     (if key
       (db/with-session [db-session (:hecuba-session store)]
         (log/debugf "Retrieving session for key: %s" key)
-        (let [user-session (first (db/execute
+        (let [user-session (first (db/execute-prepared
                                    db-session
-                                   (hayt/select :sessions
-                                                (hayt/where [[= :id key]]))))]
+                                   read-session-cql
+                                   {:values [key]}))]
           (log/debugf "Retrieved session %s" user-session)
           (clojure.edn/read-string (:data user-session))))
       {}))
   (write-session [_ key data]
     (log/debugf "Key: %s Data: %s" key (pr-str data))
-    (let [key (or key (str (java.util.UUID/randomUUID)))
-          session-data {:id key
-                        :data (pr-str data)}]
-      (log/debugf "Writing session: %s" session-data)
+    (let [key (or key (str (java.util.UUID/randomUUID)))]
+      (log/debugf "Writing session id: %s data: %s" key data)
       (db/with-session [db-session (:hecuba-session store)]
-        (db/execute
+        (db/execute-prepared
          db-session
-         (hayt/update :sessions
-                      (hayt/set-columns
-                       (dissoc session-data :id))
-                      (hayt/where [[= :id key]]))
-         {:consistency :quorum}))
+         write-session-cql
+         {:consistency :quorum
+          :values [(pr-str data) key]}))
       key))
   (delete-session [_ key]
     (log/debugf "Deleting sessiong for key: %s" key)
@@ -45,4 +41,9 @@
     nil))
 
 (defn cassandra-store [store]
-  (CassandraStore. store))
+  (let [cassandra-session (:hecuba-session store)
+        read-session-cql
+        (db/prepare-statement cassandra-session "select * from sessions where id = ?;")
+        write-session-cql
+        (db/prepare-statement cassandra-session "update sessions set data = ? where id = ?;")]
+    (CassandraStore. store read-session-cql write-session-cql)))

--- a/src/kixi/hecuba/storage/db.clj
+++ b/src/kixi/hecuba/storage/db.clj
@@ -55,6 +55,17 @@
       (alia/execute (:session this) (->raw-with-logging query) opts)
       (catch Throwable t (log/errorf t "Query execution failed: %s opts: %s" (hayt/->raw query) opts)
              (throw t))))
+  (hecuba/-prepare-statement [this statement]
+    (try
+      (alia/prepare (:session this) statement)
+      (catch Throwable t
+        (log/errorf t "Could not prepare statement: %s" statement)
+        (throw t))))
+  (hecuba/-execute-prepared [this query opts]
+    (try
+      (alia/execute (:session this) query opts)
+      (catch Throwable t (log/errorf t "Query execution failed: %s opts: %s" query opts)
+             (throw t))))
   (hecuba/-execute-async [this query opts]
     (try
       (alia/execute-async (:session this) (->raw-with-logging query) opts)
@@ -74,6 +85,10 @@
 
 (defn execute [session query & [opts]]
   (hecuba/-execute session query opts))
+(defn prepare-statement [session statement]
+  (hecuba/-prepare-statement session statement))
+(defn execute-prepared [session query & [opts]]
+  (hecuba/-execute-prepared session query opts))
 (defn execute-async [session query & [opts]]
   (hecuba/-execute-async session query opts))
 (defn execute-chan [session query & [opts]]


### PR DESCRIPTION
We hit these queries a lot, so using prepared statements and always hitting the primary key to speed things up.
