### PR TITLE
First cut at a photo migrator old-embed -> hecuba.

### DIFF
--- a/dev/photo_migration.clj
+++ b/dev/photo_migration.clj
@@ -39,10 +39,10 @@
   (db/with-session [session (:hecuba-session store)]
     (doseq [{:keys [id photos]} (entities/get-all session)]
       (log/info "migrating photos for " id)
-      (entities/update session id {:photos []})
-      (doseq [item (keep get-item-from-old-embed-bucket (map path-from photos))]
-        (log/info "migrating path for " item)
-        (upload/image-upload store  (assoc item :entity_id id))))))
+      (if-let [paths (not-empty (map path-from photos))]
+        (doseq [item (keep get-item-from-old-embed-bucket paths)]
+          (log/info "migrating path for " item)
+          (upload/image-upload store  (assoc item :entity_id id)))))))
 
 (comment
   ;; from 'user ns after (go)

--- a/src/kixi/hecuba/webutil.clj
+++ b/src/kixi/hecuba/webutil.clj
@@ -51,11 +51,16 @@
 (defn stringify-values [m]
   (into {} (for [[k v] m] [k (str v)])))
 
+;; FIXME these update-stringified-list don't work in the expected way all the time.
+;; in particular if the selector points to a non existant (nested) attribute.
 (defn update-stringified-list [body selector]
-  (update-in body [selector] #(when % (map encode %))))
+  (update-in body
+             [selector]
+             #(when % (map encode %))))
 
 (defn update-stringified-lists [body selectors]
-  (reduce update-stringified-list body selectors))
+  (let [extant-selectors (keep (partial get-in body) [selectors])]
+    (reduce update-stringified-list body extant-selectors)))
 
 (defn authorized? [store]
   (fn [ctx]


### PR DESCRIPTION
Still has some issues, but the bones are there.

It seems that some of the paths in the existing data are invalid.

e.g.

select id, photos from entities where
id='adce5e2650f7532e26b969a3f8743fab3df7cadd';

the path to the photo doesn't exist.
