### PR TITLE
Fix validation error on new property creation.

### DIFF
--- a/src-cljs/kixi/hecuba/common.cljs
+++ b/src-cljs/kixi/hecuba/common.cljs
@@ -130,3 +130,8 @@
      (when name [:p "Name: " name])
      (when latitude [:p "Latitude: " latitude])
      (when longitude [:p "Longitude: " longitude])]))
+
+(defn assoc-if [m k v]
+  (if v
+    (assoc m k v)
+    m))

--- a/src-cljs/kixi/hecuba/tabs/hierarchy/properties.cljs
+++ b/src-cljs/kixi/hecuba/tabs/hierarchy/properties.cljs
@@ -8,7 +8,7 @@
    [kixi.hecuba.tabs.hierarchy.data :refer (fetch-properties)]
    [kixi.hecuba.tabs.slugs :as slugs]
    [kixi.hecuba.bootstrap  :as bs]
-   [kixi.hecuba.common :refer (log) :as common]
+   [kixi.hecuba.common :refer (log assoc-if) :as common]
    [kixi.hecuba.widgets.fileupload :as file]
    [sablono.core :as html :refer-macros [html]]))
 
@@ -53,9 +53,8 @@
                      :onClick (fn [_] (let [property      (om/get-state owner :property)
                                             property_data (om/get-state owner :property_data)]
                                         (if (valid-property? property)
-                                          (post-new-property data owner (assoc property
-                                                                          :property_data property_data
-                                                                          :project_id project_id)
+                                          (post-new-property data owner (-> (assoc property :project_id project_id)
+                                                                            (assoc-if :property_data property_data))
                                                              project_id)
                                           (om/update! data [:properties :alert] {:status true
                                                                                  :class "alert alert-danger"

--- a/src/kixi/hecuba/api/entities.clj
+++ b/src/kixi/hecuba/api/entities.clj
@@ -206,7 +206,8 @@ their containing structures."
   (util/render-item ctx (:entities ctx)))
 
 (defn index-handle-malformed [ctx]
-  (util/render-item ctx (:malformed-msg ctx)))
+  (let [content-type (-> ctx :request :content-type)]
+    (util/render-item (assoc-in ctx [:representation :media-type] content-type) (:malformed-msg ctx))))
 
 (defn index-malformed? [ctx]
   (try

--- a/src/kixi/hecuba/api/entities/schema.clj
+++ b/src/kixi/hecuba/api/entities/schema.clj
@@ -119,7 +119,7 @@
 (defn entity-validation-failures [entity project_id]
   (if-let [validation-errors (s/check schema/Entity entity)]
     (do
-      (log/debugf "Entity %s validation errors: %s" (pr-str entity) validation-errors)
+      (log/debugf "Entity: %s validation errors: %s" (pr-str entity) (su/validation-error-explain validation-errors))
       {:received-entity entity
        :proposed-project_id project_id
        :validation-errors (su/validation-error-explain validation-errors)})


### PR DESCRIPTION
Form was associng nil property data and failing validation.
- Better validation error logging.
- Set content-type for handle-malformed in h.h.a.entities.
- Only assoc property-data if it exists on new.
