### PR TITLE
Fixed sha1 generation & sorting for profiles.

### DIFF
--- a/src-cljs/kixi/hecuba/tabs/hierarchy/profiles.cljs
+++ b/src-cljs/kixi/hecuba/tabs/hierarchy/profiles.cljs
@@ -930,7 +930,9 @@
         x-ind (order (-> x (get-in [:profile_data :event_type] "") string/lower-case))
         y-ind (order (-> y (get-in [:profile_data :event_type] "") string/lower-case))]
     (if (and x-ind y-ind)
-      (compare x-ind y-ind)
+      (if (zero? (compare x-ind y-ind))
+        (compare (:timestamp x) (:timestamp y))
+        (compare x-ind y-ind))
       (compare (:timestamp x) (:timestamp y)))))
 
 (defn profiles-div [property-details owner]

--- a/src/kixi/hecuba/storage/sha1.clj
+++ b/src/kixi/hecuba/storage/sha1.clj
@@ -21,8 +21,9 @@
 (defmethod gen-key :entity [typ payload] ((sha1-keyfn :property_code :project_id) payload))
 (defmethod gen-key :device [typ payload] ((sha1-keyfn :description :entity_id) payload))
 (defmethod gen-key :profile [typ profile] (let [entity_id (:entity_id profile)
-                                                event_type (-> profile :profile_data :event_type)]
-                                            (sha1 (pr-str entity_id event_type))))
+                                                event_type (-> profile :profile_data :event_type)
+                                                timestamp (:timestamp profile)]
+                                            (sha1 (pr-str entity_id event_type timestamp))))
 
 (defmethod gen-key :sensor [typ payload] nil)
 (defmethod gen-key :sensor_metadata [typ payload] nil)


### PR DESCRIPTION
Profiles are now unique according to entity_id, event_type and
timestamp.

Fixed sorting for when event_type is the same, then it sorts by date.
