### PR TITLE
Find min/max chart timestamps. Fixes #308

### DIFF
--- a/src-cljs/kixi/hecuba/widgets/chart.cljs
+++ b/src-cljs/kixi/hecuba/widgets/chart.cljs
@@ -70,10 +70,17 @@
 ;; Min and max
 
 (defn min-max-dates
-  "Returns min and max timestamps assuming timeseries are returned from Cassandra in an ascending order."
   [measurements]
-  {:min-date (-> measurements first :timestamp)
-   :max-date (-> measurements last :timestamp)})
+  (reduce (fn [acc {:keys [timestamp]}]
+            (if (:min-date acc)
+              (assoc acc
+                :min-date (min timestamp (:min-date acc))
+                :max-date (max timestamp (:max-date acc)))
+              (assoc acc
+                :min-date timestamp
+                :max-date timestamp)))
+          {}
+          measurements))
 
 (defn min-max-timestamps [data1 data2]
   (if (every? seq [data1 data2])


### PR DESCRIPTION
There is only one series per axis, so the 2/3/4th sensors come after the
1st and might have earlier dates.
