### PR TITLE
Stronger measurement csv upload handling

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     # Use VBoxManage to customize the VM.
     # See http://www.virtualbox.org/manual/ch08.html#idp56624480
-    vb.customize ["modifyvm", :id, "--memory", "1024"]
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
     vb.customize ["modifyvm", :id, "--cpus", "2"]
     config.vm.network "private_network", ip: "192.168.50.4", virtualbox__intnet: "kixi"
     override.vm.network :forwarded_port, guest: 9092, host: 9092 #Kafka

--- a/project.clj
+++ b/project.clj
@@ -56,9 +56,7 @@
                  ;; EDN reader with location metadata - for configuration
                  [org.clojure/tools.reader "0.8.8"]
 
-                 ;; using a patched liberator pending
-                 ;; https://github.com/clojure-liberator/liberator/issues/162
-                 [kixi/liberator "0.12.1-p0"]
+                 [liberator "0.12.2"]
                  [cheshire "5.3.1"]
 
                  ;; Required for Cassandra (possibly only OSX)

--- a/src-cljs/kixi/hecuba/history.cljs
+++ b/src-cljs/kixi/hecuba/history.cljs
@@ -57,7 +57,7 @@
                                           goog.string/urlDecode
                                           match-token)]
      (hash-map
-      :ids    (ids->map (str/split ids #","))
+      :ids    (ids->map (str/split (goog.string/urlDecode ids) #","))
       :search (str/split search-terms #"@@@"))))
 
 (defn- historian->token [{:keys [ids search]}]
@@ -107,7 +107,7 @@
 (defn update-token-ids! [history k v & keep-all?]
   (let [{:keys [ids] :as tmap} (token-as-map history)
         keep-keys              (if keep-all? key-order (take-while #(not (keyword-identical? % k)) key-order))
-        new-ids                (assoc (select-keys ids keep-keys) k v)]
+        new-ids                (assoc (select-keys ids keep-keys) k (goog.string/urlEncode v))]
     (set-token! history (assoc tmap :ids new-ids) historian->token)))
 
 (defn set-token-search! [history xs]

--- a/src-cljs/kixi/hecuba/widgets/measurementsupload.cljs
+++ b/src-cljs/kixi/hecuba/widgets/measurementsupload.cljs
@@ -69,8 +69,12 @@
                  [:option {:value (:format item)}
                   (:display item)])]]
              [:div.form-group
-              [:label {:for "file"} "File Input"]
-              [:input {:type "file" :id "file" :name "data" :title "Browse files"}]]
+              [:div
+               [:label {:for "file"} "File Input"]
+               [:input {:type "file" :id "file" :name "data" :title "Browse files"}]]
+              [:div {:class "checkbox"} [:label
+                                         [:input {:type "checkbox" :name "aliases"}]
+                                         "Assume Aliases?"]]]
              [:button {:type "button"
                        :class "btn btn-primary"
                        :onClick (fn [_] (validate-size-and-upload uploads owner id url method))}

--- a/src/kixi/hecuba/api/uploads.clj
+++ b/src/kixi/hecuba/api/uploads.clj
@@ -1,21 +1,14 @@
 (ns kixi.hecuba.api.uploads
-  (:require [clojure.tools.logging :as log]
-            [liberator.core :refer (defresource)]
+  (:require [cheshire.core :as json]
+            [clj-time.coerce :as tc]
+            [clojure.core.match :refer (match)]
+            [clojure.tools.logging :as log]
+            [kixi.hecuba.security :refer (has-admin? has-programme-manager? has-project-manager? has-user?) :as sec]
+            [kixi.hecuba.web-paths :as p]
+            [kixi.hecuba.webutil :as util]
             [kixi.hecuba.webutil :refer (authorized?)]
             [kixipipe.storage.s3 :as s3]
-            [kixi.hecuba.web-paths :as p]
-            [kixi.hecuba.security :refer (has-admin? has-programme-manager? has-project-manager? has-user?) :as sec]
-            [kixi.hecuba.data.projects :as projects]
-            [kixi.hecuba.data.entities :as entities]
-            [kixi.hecuba.data.measurements.core :as mc]
-            [clojure.core.match :refer (match)]
-            [clojure.string :as str]
-            [cheshire.core :as json]
-            [aws.sdk.s3 :as aws]
-            [clj-time.coerce :as tc]
-            [kixi.hecuba.webutil :as util]
-            [kixipipe.storage.s3 :as s3]
-            [liberator.representation :refer (ring-response)]))
+            [liberator.core :refer (defresource)]))
 
 (def ^:private uploads-status-path (p/resource-path-string :uploads-status-resource))
 (def ^:private uploads-data-path (p/resource-path-string :uploads-data-resource))

--- a/src/kixi/hecuba/data/measurements/core.clj
+++ b/src/kixi/hecuba/data/measurements/core.clj
@@ -9,6 +9,7 @@
                        :customer_ref
                        :description
                        :location
+                       :unit
                        :accuracy
                        :resolution
                        :frequency
@@ -27,6 +28,7 @@
                        "Customer Ref"
                        "Description"
                        "Location"
+                       "Unit"
                        "Accuracy (percent)"
                        "Sample Interval (seconds)"
                        "Frequency"
@@ -47,7 +49,7 @@
     (try
       (spit status-file (json/generate-string (select-keys item [:status :data])))
       (s3/store-file (:s3 store) (-> item
-                                     (assoc 
+                                     (assoc
                                          :dir (.getParent status-file)
                                          :filename (.getName status-file)
                                          :suffix "status"

--- a/src/kixi/hecuba/data/misc.clj
+++ b/src/kixi/hecuba/data/misc.clj
@@ -31,12 +31,12 @@
 (defn daily-timestamp [t]
   (tc/to-date (tf/unparse (tf/formatters :date) (tc/from-date t))))
 
-(defn get-year-partition-key [timestamp] (Long/parseLong (format "%4d" (t/year timestamp))))
+(defn get-year-partition-key [timestamp] (Long/parseLong (format "%04d" (t/year timestamp))))
 
 (defmulti get-month-partition-key type)
 (defmethod get-month-partition-key java.util.Date [t]
-  (let [timestamp (tc/from-date t)] (Long/parseLong (format "%4d%02d" (t/year timestamp) (t/month timestamp)))))
-(defmethod get-month-partition-key org.joda.time.DateTime [t] (Long/parseLong (format "%4d%02d" (t/year t) (t/month t))))
+  (let [timestamp (tc/from-date t)] (Long/parseLong (format "%04d%02d" (t/year timestamp) (t/month timestamp)))))
+(defmethod get-month-partition-key org.joda.time.DateTime [t] (Long/parseLong (format "%04d%02d" (t/year t) (t/month t))))
 
 (defmulti truncate-seconds type)
 (defmethod truncate-seconds java.util.Date [t]

--- a/src/kixi/hecuba/parser.clj
+++ b/src/kixi/hecuba/parser.clj
@@ -1,0 +1,8 @@
+(ns kixi.hecuba.parser
+  (:require [clojure.java.io :as io]))
+
+(defn normalize-line-endings! [input output]
+  (with-open [in  (io/reader input)
+              out (java.io.PrintWriter. output)]
+	(doseq [line (line-seq in)]
+	  (.println out line))))

--- a/test/kixi/hecuba/api/templates_test.clj
+++ b/test/kixi/hecuba/api/templates_test.clj
@@ -121,7 +121,9 @@
                                    :frequency "frequency3000/2"
                                    :period "CUMULATIVE"
                                    :max "200"
-                                   :min "10"}
+                                   :min "10"
+                                   :unit "kWh"
+                                   }
                                   {:device_id 3000
                                    :type "CO2"
                                    :accuracy "0"
@@ -129,7 +131,9 @@
                                    :frequency "frequency3000/1"
                                    :period "INSTANT"
                                    :max "100"
-                                   :min "0"}
+                                   :min "0"
+                                   :unit "m^3"
+                                   }
                                   {:device_id 3000
                                    :type "solarRadiation"
                                    :accuracy "10"
@@ -137,7 +141,9 @@
                                    :frequency "frequency3000/3"
                                    :period "PULSE"
                                    :max "450"
-                                   :min "100"}
+                                   :min "100"
+                                   :unit "J/m^2"
+                                   }
                                   {:device_id 3001
                                    :type "CO2"
                                    :accuracy "5"
@@ -145,7 +151,8 @@
                                    :frequency "frequency3001/1"
                                    :period "INSTANT"
                                    :max "10"
-                                   :min "5"}])
+                                   :min "5"
+                                   :unit "m^3"}])
         pipeline                   nil
         result   (entity-resource-handle-ok store pipeline
                                             {:request {:params {:entity_id 1000}}
@@ -166,6 +173,7 @@
                 "description"
                 "description2"]
                ["Location" "Bedroom" "Bedroom" "Bedroom" "Lounge"]
+               ["Unit" "m^3" "kWh" "J/m^2" "m^3"]
                ["Accuracy (percent)" "0" "5" "10" "5"]
                ["Sample Interval (seconds)" "60" "30" "40" "6"]
                ["Frequency"


### PR DESCRIPTION
Fixes #366 and allows user to upload using aliases/header rows even if the file is in canonical measurement upload format, but using different identifiers (as with data from old embed).

Fixes #367 
