### PR TITLE
Allow for space chars in url path.

### DIFF
--- a/src-cljs/kixi/hecuba/history.cljs
+++ b/src-cljs/kixi/hecuba/history.cljs
@@ -11,7 +11,7 @@
 ;; (enable-console-print!)
 
 (defn match-token [s]
-  (re-matches #"((?:[A-Za-z0-9-_;]+)(?:,(?:[A-Za-z0-9-_;]+))*)(?:/search/(.*))?" s))
+  (re-matches #"((?:[A-Za-z0-9-_; ]+)(?:,(?:[A-Za-z0-9-_; ]+))*)(?:/search/(.*))?" s))
 
 ;; TODO let's not use an atom for this.
 (def ^:private key-order (atom []))
@@ -107,7 +107,7 @@
 (defn update-token-ids! [history k v & keep-all?]
   (let [{:keys [ids] :as tmap} (token-as-map history)
         keep-keys              (if keep-all? key-order (take-while #(not (keyword-identical? % k)) key-order))
-        new-ids                (assoc (select-keys ids keep-keys) k (goog.string/urlEncode v))]
+        new-ids                (assoc (select-keys ids keep-keys) k (when v (goog.string/urlEncode v)))]
     (set-token! history (assoc tmap :ids new-ids) historian->token)))
 
 (defn set-token-search! [history xs]

--- a/src-cljs/kixi/hecuba/tabs/hierarchy/sensors.cljs
+++ b/src-cljs/kixi/hecuba/tabs/hierarchy/sensors.cljs
@@ -49,8 +49,7 @@
                        parent-device lower_ts upper_ts actual_annual selected]} sensor
                        {:keys [description privacy location]} parent-device
                        id (str type "-" device_id)
-                       selected? (contains? (:selected sensors) id)
-                       history (om/get-shared owner :history)]
+                       selected? (contains? (:selected sensors) id)]
            [:tr {:onClick (fn [e] (put! selected-chan {:id id
                                                        :unit unit
                                                        :upper_ts upper_ts


### PR DESCRIPTION
Fixes #368 

Allow for space characters in history and URL
- History regex now allows for space characters
- Fix bug in update-token-ids! where nil values where encoded to "null" and therefore placed in url/history
