### PR TITLE
Better status reporting and logging of uploads

### DIFF
--- a/src/kixi/hecuba/api/measurements.clj
+++ b/src/kixi/hecuba/api/measurements.clj
@@ -5,6 +5,7 @@
    [clojure.tools.logging :as log]
    [kixipipe.pipeline :as pipe]
    [kixi.hecuba.data.measurements :as measurements]
+   [kixi.hecuba.data.measurements.core :as mc]
    [kixi.hecuba.data.misc :as misc]
    [kixi.hecuba.data.validate :as v]
    [kixi.hecuba.security :refer (has-admin? has-programme-manager? has-project-manager? has-user?) :as sec]
@@ -199,6 +200,8 @@
         auth         (sec/current-authentication session)
         items        (map (partial template-upload->item entity_id username date-format aliases?) file-data)]
     (doseq [item items]
+      (log/infof "Accepted upload: %s" item)
+      (mc/write-status store (assoc item :status "ACCEPTED"))
       (pipe/submit-item pipe (assoc item :auth auth)))
     ;; We don't have emough info to return a Location header here. So
     ;; we return nothing. This seems to be in line with the HTTP spec.

--- a/src/kixi/hecuba/data/measurements/core.clj
+++ b/src/kixi/hecuba/data/measurements/core.clj
@@ -65,11 +65,15 @@
     []))
 
 (defn prepare-measurement [m sensor date-parser]
-  (let [t  (tc/to-date (date-parser (:timestamp m)))]
-    {:device_id        (:device_id sensor)
-     :type             (:type sensor)
-     :timestamp        t
-     :value            (str (:value m))
-     :error            (str (:error m))
-     :month            (time/get-month-partition-key t)
-     :reading_metadata {}}))
+  (try
+    (let [t  (tc/to-date (date-parser (:timestamp m)))]
+      {:device_id        (:device_id sensor)
+       :type             (:type sensor)
+       :timestamp        t
+       :value            (str (:value m))
+       :error            (str (:error m))
+       :month            (time/get-month-partition-key t)
+       :reading_metadata {}})
+    (catch Throwable t
+      (log/errorf t "For sensor %s Unable to prepare measurement: %s" sensor m)
+      (throw t))))

--- a/src/kixi/hecuba/data/measurements/upload.clj
+++ b/src/kixi/hecuba/data/measurements/upload.clj
@@ -300,8 +300,8 @@
       (finally (ioplus/delete! in-file)))))
 
 (defn upload-item [store item]
-  (log/infof "Accepted upload: %s" item)
-  (write-status store (assoc item :status "ACCEPTED"))
+  (log/infof "Storing upload: %s" item)
+  (write-status store (assoc item :status "STORING"))
   (s3/store-file (:s3 store) item)
   (write-status store (assoc item :status "STORED"))
   (log/infof "Stored upload: %s" item)


### PR DESCRIPTION
- Update status immediately when file arrives to ACCEPTED
- Change status to STORING when saving to s3.
- Better logging of while measurement failed to insert.
