### PR TITLE
Variable headers on standard measurement csv files

### DIFF
--- a/src/kixi/hecuba/data/measurements/aliases.clj
+++ b/src/kixi/hecuba/data/measurements/aliases.clj
@@ -4,16 +4,13 @@
             [clojure.java.io :as io]
             [clojure.string :as str]
             [kixi.hecuba.data.measurements.core :refer (transpose)]
-            [kixi.hecuba.data.measurements.upload :refer (date-parser)]))
+            [kixi.hecuba.data.measurements.upload :refer (date-parser-fn parse-header-rows)]))
 
 (defn from-file [filename date-format]
-  (let [blank-row?    (fn [cells] (every? #(re-matches #"\s*" %) cells))
-        date-parser   (fn [d] (try ((date-parser date-format) d) (catch Throwable t nil)))
-        invalid-date? (complement date-parser)
-        header-rows   (with-open [in (io/reader (io/file filename))]
-                        (->> in
-                             (csv/read-csv)
-                             (take-while (comp invalid-date? first))
-                             (remove blank-row?)
-                             (doall)))]
+  (let [date-parser (date-parser-fn date-format)
+        header-rows (with-open [in (io/reader (io/file filename))]
+                      (->> in
+                           (csv/read-csv)
+                           (parse-header-rows date-parser)
+                           (doall)))]
     (mapv (partial str/join \|) (rest (transpose header-rows)))))

--- a/src/kixi/hecuba/data/measurements/core.clj
+++ b/src/kixi/hecuba/data/measurements/core.clj
@@ -16,10 +16,7 @@
                        :resolution
                        :frequency
                        :period
-                       :entity_id ;; NOTE: This is shown as "Parent
-                                  ;; UUID" in the samples. Assuming
-                                  ;; parent_id column is old API and
-                                  ;; using entity_id instead
+                       :entity_id ; labelled as Parent UUID
                        :max
                        :min])
 
@@ -38,6 +35,23 @@
                        "Parent UUID"
                        "Sensor Range Max"
                        "Sensor Range Min"])
+
+(defn keywordise [label]
+  (get
+   {"Unit" :unit
+    "Period" :period
+    "Sample Interval (seconds)" :resolution
+    "Customer Ref" :customer_ref
+    "Sensor Range Max" :max
+    "Parent UUID" :entity_id
+    "Location" :location
+    "Description" :description
+    "Reading Type" :type
+    "Device UUID" :device_id
+    "Accuracy (percent)" :accuracy
+    "Frequency" :frequency
+    "Sensor Range Min" :min}
+   label))
 
 (defn get-status [{:keys [s3]} item]
   ;; TODO there should be a better way to do this in s3 ns.

--- a/test/kixi/hecuba/data/measurements/upload_test.clj
+++ b/test/kixi/hecuba/data/measurements/upload_test.clj
@@ -14,12 +14,13 @@
 
 ;; These dates supplied by Geoff Stevens in e-mail Thu, 21 Aug 2014 16:43:07 +0000
 (deftest geoff-date-formats-test
-  (is (= ((date-parser nil) "30/12/2013 00:00")
+  (is (= ((date-parser-fn nil) "30/12/2013 00:00")
          (t/date-time 2013 12 30)))
-  (is (= ((date-parser "") "30/12/2013 00:00:00")
+  (is (= ((date-parser-fn "") "30/12/2013 00:00:00")
          (t/date-time 2013 12 30)))
-  (is (= ((date-parser "") "2011-10-01T00:10:00+00:00")
-         (t/date-time 2011 10 1 0 10))))
+  (is (= ((date-parser-fn "") "2011-10-01T00:10:00+00:00")
+         (t/date-time 2011 10 1 0 10)))
+  (is (nil? ((date-parser-fn "") ""))))
 
 (deftest s3-key-from-test
   (is (= (s3-key-from {:src-name "uploads" :metadata {:username "foo@example.com"} :entity_id 1234})
@@ -32,3 +33,90 @@
          (item-from-s3-key "uploads/foo@example.com/1234/12312"))
       (= nil
          (item-from-s3-key "uploads/1234/123/"))))
+
+(def sample-csv
+  [["Device UUID" "b0601d9c9829f40503ff452f6059fdca870868cd" "a13676c830412d44e6fbc90f40376eb7fdd05064"]
+   ["Reading Type" "Temperature Air" "Temperature"]
+   ["Customer Ref" "32394tt" "32394lt"]
+   ["Description" "32394 - HallAirTemperature" "32394 - living room temperature"]
+   ["Location" "hall" "living room"]
+   ["Accuracy (percent)" "" ""]
+   ["Sample Interval (seconds)" "3600" "3600"]
+   ["Frequency" "" ""]
+   ["Period" "INSTANT" "INSTANT"]
+   ["Parent UUID" "" ""]
+   ["Sensor Range Max" "60" "60"]
+   ["Sensor Range Min" "-30" "-30"]])
+
+(def expected-devices
+  [{:description "32394 - HallAirTemperature",
+    :min "-30",
+    :customer_ref "32394tt",
+    :accuracy "",
+    :frequency "",
+    :type "Temperature Air",
+    :resolution "3600",
+    :max "60",
+    :entity_id "",
+    :period "INSTANT",
+    :device_id "b0601d9c9829f40503ff452f6059fdca870868cd",
+    :location "hall"}
+   {:description "32394 - living room temperature",
+    :min "-30",
+    :customer_ref "32394lt",
+    :accuracy "",
+    :frequency "",
+    :type "Temperature",
+    :resolution "3600",
+    :max "60",
+    :entity_id "",
+    :period "INSTANT",
+    :device_id "a13676c830412d44e6fbc90f40376eb7fdd05064",
+    :location "living room"}])
+
+(def sample-csv-with-unit
+  [["Device UUID" "b0601d9c9829f40503ff452f6059fdca870868cd" "a13676c830412d44e6fbc90f40376eb7fdd05064"]
+   ["Reading Type" "Temperature Air" "Temperature"]
+   ["Customer Ref" "32394tt" "32394lt"]
+   ["Unit" "degC" "degC"]
+   ["Description" "32394 - HallAirTemperature" "32394 - living room temperature"]
+   ["Location" "hall" "living room"]
+   ["Accuracy (percent)" "" ""]
+   ["Sample Interval (seconds)" "3600" "3600"]
+   ["Frequency" "" ""]
+   ["Period" "INSTANT" "INSTANT"]
+   ["Parent UUID" "" ""]
+   ["Sensor Range Max" "60" "60"]
+   ["Sensor Range Min" "-30" "-30"]])
+
+(def expected-devices-with-unit
+  [{:description "32394 - HallAirTemperature",
+    :unit "degC"
+    :min "-30",
+    :customer_ref "32394tt",
+    :accuracy "",
+    :frequency "",
+    :type "Temperature Air",
+    :resolution "3600",
+    :max "60",
+    :entity_id "",
+    :period "INSTANT",
+    :device_id "b0601d9c9829f40503ff452f6059fdca870868cd",
+    :location "hall"}
+   {:description "32394 - living room temperature",
+    :unit "degC"
+    :min "-30",
+    :customer_ref "32394lt",
+    :accuracy "",
+    :frequency "",
+    :type "Temperature",
+    :resolution "3600",
+    :max "60",
+    :entity_id "",
+    :period "INSTANT",
+    :device_id "a13676c830412d44e6fbc90f40376eb7fdd05064",
+    :location "living room"}])
+
+(deftest parse-vertical-header
+  (is (= expected-devices (vec (parse-full-header sample-csv))))
+  (is (= expected-devices-with-unit (vec (parse-full-header sample-csv-with-unit)))))


### PR DESCRIPTION
Use the fields in column 0 as a way of generating keys so we can deal
with csv files in the canonical format having varying header sizes.

Uses the same invalid-date? parsing that aliased headers do, but uses
the values in column 0 to create device/sensor maps out of the rest of
the headers.
