### PR TITLE
Detailed upload status reports.

### DIFF
--- a/cql/hecuba-schema.cql
+++ b/cql/hecuba-schema.cql
@@ -425,6 +425,30 @@ CREATE TABLE sessions (
   compaction={'class': 'SizeTieredCompactionStrategy'} AND
   compression={'sstable_compression': 'SnappyCompressor'};
 
+CREATE TABLE upload_status (
+  entity_id text,
+  filename text,
+  username text,
+  event_time timestamp,
+  status text,
+  report text,
+  PRIMARY KEY (entity_id, filename)
+) WITH
+  bloom_filter_fp_chance=0.010000 AND
+  caching='KEYS_ONLY' AND
+  comment='' AND
+  dclocal_read_repair_chance=0.000000 AND
+  gc_grace_seconds=864000 AND
+  index_interval=128 AND
+  read_repair_chance=0.100000 AND
+  replicate_on_write='true' AND
+  populate_io_cache_on_flush='false' AND
+  default_time_to_live=0 AND
+  speculative_retry='99.0PERCENTILE' AND
+  memtable_flush_period_in_ms=0 AND
+  compaction={'class': 'SizeTieredCompactionStrategy'} AND
+  compression={'sstable_compression': 'SnappyCompressor'};
+
 CREATE TABLE users (
   id text,
   data text,

--- a/resources/site/css/hecuba.css
+++ b/resources/site/css/hecuba.css
@@ -59,10 +59,6 @@ p#footer {
     margin-bottom: 0px;
 }
 
-.row {
-    min-height: 200px;
-}
-
 #summary-stats {
     min-height: 100px;
 }

--- a/src-cljs/kixi/hecuba/tabs/hierarchy/data.cljs
+++ b/src-cljs/kixi/hecuba/tabs/hierarchy/data.cljs
@@ -272,8 +272,9 @@
 
 (defn fetch-upload-status [programme_id project_id entity_id data]
   (log "Fetching upload status for entity: " entity_id)
+  (om/update! data [:properties :uploads :fetching] :fetching)
   (GET (str "/4/uploads/for-username/programme/" programme_id "/project/" project_id "/entity/" entity_id "/status")
        {:handler (fn [d]
-                   (log "Received: " d)
+                   (om/update! data [:properties :uploads :fetching] (if (seq d) :has-data :no-data))
                    (om/update! data [:properties :uploads :files] d))
         :headers {"Accept" "application/edn"}}))

--- a/src-cljs/kixi/hecuba/tabs/hierarchy/status.cljs
+++ b/src-cljs/kixi/hecuba/tabs/hierarchy/status.cljs
@@ -4,40 +4,75 @@
             [cljs.core.async :refer [chan put!]]
             [kixi.hecuba.common :refer (log) :as common]))
 
+(defn panel-status [status inserted-devices devices]
+  (cond
+   (and (= inserted-devices devices) (or (= status "COMPLETE") (= status "SUCCESS"))) "panel-success"
+        (and (< inserted-devices devices) (or (= status "COMPLETE") (= status "SUCCESS"))) "panel-warning"
+        (= status "FAILURE") "panel-danger"
+        :else "panel-info"))
+
+(defn skip-reason [sensor]
+  (let [metadata (:metadata sensor)
+        {:keys [exists? allowed?]} metadata]
+    (cond (not exists?) "No matching sensor found."
+          (not allowed?) "Not allowed to upload to this sensor."
+          :else (str "Exists: " exists? " Allowed: " allowed?))))
+
 (defn upload-status [programme_id project_id entity_id]
   (fn [cursor owner]
     (reify
       om/IDisplayName
       (display-name [_]
         "Measurement Upload Status")
-      om/IWillMount
-      (will-mount [_]
-        (let [refresh-chan (om/get-shared owner :refresh)]
-          (put! refresh-chan {:event :upload-status})
-          ;; (js/setInterval (fn [] (put! refresh-chan {:event :upload-status})) 60000)
-          ))
       om/IRender
       (render [_]
-        (html
-         [:div
-          [:table.table.table-hover.table-condensed
-           [:thead
-            [:tr
-             [:th "File"]
-             [:th "Timestamp"]
-             [:th "Status"]]
-            [:tbody
-             (for [item cursor]
-               (let [status (:status item)]
-                 [:tr
-                  [:td (:filename item)]
-                  [:td (common/unparse-date-str (:timestamp item) "yyyy-MM-dd HH:mm:ss")]
-                  [:td (cond (or (= status "COMPLETE") (= status "SUCCESS"))
-                             [:span {:class "label label-success"} status]
-                             (= status "FAILURE")
-                             [:span {:class "label label-danger"} status]
-                             :else
-                             [:span {:class "label label-info"} status])]]))]]]])))))
+        (let [sorted-statuses (sort-by :event_time #(* -1 (compare %1 %2)) cursor)]
+          (html
+           [:div.col-md-12
+            (for [item sorted-statuses]
+              (let [status (:status item)
+                    all-sensors (group-by #(-> % :metadata :inserted) (:report item))
+                    inserted-sensors (get all-sensors true)
+                    skipped-sensors (get all-sensors false)
+                    inserted-sensor-count (count inserted-sensors)
+                    total-sensor-count (count (:report item))]
+                [:div.row
+                 [:div {:class (str "panel " (panel-status status inserted-sensor-count total-sensor-count))}
+                  [:div.panel-heading (:filename item) [:div.pull-right [:strong status]]]
+                  [:div.panel-body
+                   [:table.table.table-hover.table-condensed
+                    [:thead
+                     [:tr [:th "Uploaded by"] [:th "Timestamp"] [:th "Inserted"]]]
+                    [:tbody
+                     [:tr [:td (:username item)]
+                      [:td (common/unparse-date (:event_time item) "yyyy-MM-dd hh:mm")]
+                      [:td (str inserted-sensor-count "/" total-sensor-count)]]]]
+                   (when (< inserted-sensor-count total-sensor-count)
+                     [:div.col-md-12
+                      (when (seq inserted-sensors)
+                        [:div.row
+                         [:h4 "Inserted Devices"]
+                         [:table.table.table-hover.table-condensed
+                          [:thead
+                           [:tr [:th "Device Name"] [:th "Sensor Type"] [:th "API Sensor ID"]]]
+                          [:tbody
+                           (for [sensor inserted-sensors]
+                             [:tr
+                              [:td (:description sensor)]
+                              [:td (:type sensor)]
+                              [:td (str (:device_id sensor) ":" (:type sensor))]])]]])
+                      (when (seq skipped-sensors)
+                        [:div.row
+                         [:h4 "Skipped Devices"]
+                         [:table.table.table-hover.table-condensed
+                          [:thead
+                           [:tr [:th "Identifier"] [:th "Skip Reasons"]]]
+                          [:tbody
+                           (for [sensor skipped-sensors]
+                             [:tr
+                              [:td (or (:alias sensor) (str (:device_id sensor) ":" (:type sensor)))]
+                              [:td
+                               (skip-reason sensor)]])]]])])]]]))]))))))
 
 (defn download-status [cursor owner]
   (reify

--- a/src-cljs/kixi/hecuba/widgets/measurementsupload.cljs
+++ b/src-cljs/kixi/hecuba/widgets/measurementsupload.cljs
@@ -44,8 +44,7 @@
            [:div
             (alert "alert alert-info "
                    [:div
-                    [:div {:class "fa fa-spinner fa-spin"}] ;; needs to be separate as otherwise it spins the text as well
-                    [:p "Upload in progress"]]
+                    [:p [:div {:class "fa fa-spinner fa-spin"}] "Upload in progress"]]
                    (= :uploading status)
                    (str id "-uploading"))
 
@@ -57,7 +56,7 @@
 
             (alert "alert alert-danger "
                    [:div
-                    [:div {:class "fa fa-exclamation-triangle"} " Failed to parse CSV."]]
+                    [:div {:class "fa fa-exclamation-triangle"} " Failed to upload CSV."]]
                    (= :failure status)
                    (str id "-failure"))
 

--- a/src/kixi/hecuba/api/measurements.clj
+++ b/src/kixi/hecuba/api/measurements.clj
@@ -6,6 +6,7 @@
    [kixipipe.pipeline :as pipe]
    [kixi.hecuba.data.measurements :as measurements]
    [kixi.hecuba.data.measurements.core :as mc]
+   [kixi.hecuba.data.measurements.upload :as upload]
    [kixi.hecuba.data.misc :as misc]
    [kixi.hecuba.data.validate :as v]
    [kixi.hecuba.security :refer (has-admin? has-programme-manager? has-project-manager? has-user?) :as sec]
@@ -201,7 +202,7 @@
         items        (map (partial template-upload->item entity_id username date-format aliases?) file-data)]
     (doseq [item items]
       (log/infof "Accepted upload: %s" item)
-      (mc/write-status store (assoc item :status "ACCEPTED"))
+      (upload/write-status (assoc item :status "ACCEPTED") store)
       (pipe/submit-item pipe (assoc item :auth auth)))
     ;; We don't have emough info to return a Location header here. So
     ;; we return nothing. This seems to be in line with the HTTP spec.

--- a/src/kixi/hecuba/data/measurements/upload/status.clj
+++ b/src/kixi/hecuba/data/measurements/upload/status.clj
@@ -1,0 +1,51 @@
+(ns kixi.hecuba.data.measurements.upload.status
+  (:require [clojure.tools.logging :as log]
+            [qbits.hayt :as hayt]
+            [cheshire.core :as json]
+            [schema.core :as s]
+            [kixi.hecuba.storage.db :as db]
+            [kixi.hecuba.logging :as hl]))
+
+(def Status
+  {(s/required-key :entity_id)  s/Str
+   (s/optional-key :event_time) s/Any ;; should be a date
+   (s/required-key :filename)   s/Str
+   (s/required-key :username)   s/Str
+   (s/required-key :status)     s/Str
+   (s/required-key :report)     s/Any})
+
+(defn decode [status]
+  (-> status
+      (assoc :report (json/parse-string (:report status) keyword))))
+
+(defn encode [status]
+  (-> status
+      (assoc :report (json/encode (:report status)))))
+
+(defn get-by-id [entity_id filename store]
+  (db/with-session [session (:hecuba-session store)]
+    (let [[status & rest] (db/execute
+                           session
+                           (hayt/select :upload_status
+                                        (hayt/where [[= :entity_id entity_id]
+                                                     [= :filename filename]])))]
+      (decode status))))
+
+(defn get-statuses [entity_id store]
+  (db/with-session [session (:hecuba-session store)]
+    (let [statuses (db/execute session
+                               (hayt/select :upload_status
+                                            (hayt/where [[= :entity_id entity_id]])))]
+      (mapv decode statuses))))
+
+(defn insert [status store]
+  (s/validate Status status)
+  (db/with-session [session (:hecuba-session store)]
+    (try
+      (let [encoded-status (encode status)]
+        (db/execute session
+                    (hayt/insert :upload_status
+                                 (hayt/values encoded-status))))
+      (catch Throwable t
+        (log/errorf "Could not insert: %s" (pr-str status))
+        (throw t)))))


### PR DESCRIPTION
Data layer for upload status that stores report and status of csv
measurement upload n Cassandra rather than S3 and a refresh button for
status.

Fixes #345 

The new upload_status table in hecuba-schema.cql needs to be created as a part of this deployment.
