### PR TITLE
Rename EventType protocol.

### DIFF
--- a/src-cljs/kixi/hecuba/history.cljs
+++ b/src-cljs/kixi/hecuba/history.cljs
@@ -77,7 +77,7 @@
        token->historian))
 
 (extend-type goog.History
-  event/EventType
+  event/IEventType
   (event-types [this]
     (into {}
           (map


### PR DESCRIPTION
ClojureScript 0.0-2311 changed the event/EventType protocol to event/IEventType. This change will remove the warning about bad method signature.
