### PR TITLE
Don't encode user_metadata if it's empty.

### DIFF
--- a/src/kixi/hecuba/api/devices.clj
+++ b/src/kixi/hecuba/api/devices.clj
@@ -205,8 +205,7 @@
           ;; TODO when new sensors are created they do not necessarilly overwrite old sensors (unless their type is the same)
           ;; We should probably allow to delete sensors through the API/UI
           (doseq [reading (:readings new-body)]
-            ;; cassandra's insert only updates specified keys so no need to use update
-            (sensors/insert session (assoc reading :device_id device_id
+            (sensors/update session (assoc reading :device_id device_id
                                            :user_id user_id)))
           (-> (search/searchable-entity-by-id entity_id session)
               (search/->elasticsearch (:search-session store)))

--- a/src/kixi/hecuba/data/sensors.clj
+++ b/src/kixi/hecuba/data/sensors.clj
@@ -45,7 +45,7 @@
      (encode sensor false))
   ([sensor remove-pk?]
      (-> sensor
-         (user-metadata (:synthetic sensor))
+         (cond-> (seq (:user-metadata sensor)) (user-metadata (:synthetic sensor)))
          (cond-> remove-pk? (dissoc :device_id :type)))))
 
 (defn sensor-time-range [sensor session]


### PR DESCRIPTION
Fixes #417 

Encode function in k.h.d.sensors was updating user_metadata even when it wasn't edited. This PR adds a check to encode that will allow to edit user_metadata only when new metadata is passed. Existing metadata will remain unchanged.
