### PR TITLE
Delete sensors.

### DIFF
--- a/src/kixi/hecuba/data/misc.clj
+++ b/src/kixi/hecuba/data/misc.clj
@@ -72,7 +72,7 @@
     (let [sensor (first (db/execute session
                                     (hayt/select :sensors (hayt/where [[= :device_id device_id]
                                                                        [= :type type]]))))]
-      (merge-sensor-metadata store sensor))))
+      (merge-sensor-metadata store {:device_id device_id :type type}))))
 
 (defn all-sensor-metadata-for-device
   "Given device_id, retrieves all sensors metadata."

--- a/src/kixi/hecuba/data/sensors.clj
+++ b/src/kixi/hecuba/data/sensors.clj
@@ -84,10 +84,11 @@
 
 (defn get-by-id
   ([{:keys [device_id type]} session]
-     (db/execute session
-                 (hayt/select :sensors
-                              (hayt/where [[= :type type]
-                                           [= :device_id device_id]])))))
+     (-> (db/execute session
+                     (hayt/select :sensors
+                                  (hayt/where [[= :type type]
+                                               [= :device_id device_id]])))
+         first)))
 
 (defn insert
   ([session sensor metadata]

--- a/src/kixi/hecuba/routes.clj
+++ b/src/kixi/hecuba/routes.clj
@@ -139,6 +139,7 @@
    ;; Entity/Devices
    (index-routes :entity-devices-index [:entity_id] (devices/index store))
    (resource-route :entity-device-resource [:entity_id :device_id] (devices/resource store))
+   (resource-route :entity-device-sensor-resource [:entity_id :device_id :type] (devices/sensor-resource store))
 
    ;; Measurements
    (index-routes :entity-device-measurement-index [:entity_id :device_id] (measurements/index store s3 pipeline-head))

--- a/src/kixi/hecuba/web_paths.clj
+++ b/src/kixi/hecuba/web_paths.clj
@@ -44,6 +44,7 @@
    ;; devices
    :entity-devices-index "entities/%s/devices"
    :entity-device-resource "entities/%s/devices/%s"
+   :entity-device-sensor-resource "entities/%s/devices/%s/%s"
 
    ;; profiles
    :entity-profiles-index "entities/%s/profiles"


### PR DESCRIPTION
- Add API endpoint to delete sensor (doesn't delete measurements)
- Add delete button to Edit Device UI
- Remove alert banner when new view is loaded (which previously was displayed throughout different views unless it was closed by the user).

Fixes #386 

![image](https://cloud.githubusercontent.com/assets/2522010/4847226/1935293c-6051-11e4-9a0a-c72a485a2500.png)
