### PR TITLE
Fix y domain range.

### DIFF
--- a/src-cljs/kixi/hecuba/widgets/chart.cljs
+++ b/src-cljs/kixi/hecuba/widgets/chart.cljs
@@ -107,7 +107,7 @@
 ;; Draw chart
 
 (defn y-scale [min max height]
-  (-> js/d3 .-scale (.linear) (.domain (to-array [min max])) (.range (to-array [height min]))))
+  (-> js/d3 .-scale (.linear) (.domain (to-array [min max])) (.range (to-array [height 0]))))
 
 (defn line-fn [x-scale y-scale]
   (doto (-> js/d3 .-svg (.line))


### PR DESCRIPTION
This will fix the issue of the y-axis marks going in the wrong direction because the browser consider's the origin (0,0) point to the the upper-left corner, and we were passing [height, min] where min should be 0 so that the values are not flipped to the other side.

Fixes #444 
