### PR TITLE
Don't escape query string.

### DIFF
--- a/src/kixi/hecuba/data/entities/search.clj
+++ b/src/kixi/hecuba/data/entities/search.clj
@@ -120,7 +120,7 @@
      (let [query {:query {:filtered
                           {:query
                            {:query_string
-                            {:query (esc/escape-query-string-characters query-string)}}
+                            {:query query-string}}
                            :filter filter-map}}}]
        (search/search search-session "entities" "entity" (assoc query :size size :from from))))
   ([query-string from size search-session]
@@ -128,7 +128,7 @@
                     "entities"
                     "entity"
                     :query {:query_string
-                            {:query (esc/escape-query-string-characters query-string)}}
+                            {:query query-string}}
                     :size size
                     :from from))
   ([query-string filter-map search-session]


### PR DESCRIPTION
It stops wildcards and other things from working.

This fixes the basic project search.
