### PR TITLE
Better sorting

### DIFF
--- a/src-cljs/kixi/hecuba/bootstrap.cljs
+++ b/src-cljs/kixi/hecuba/bootstrap.cljs
@@ -1,7 +1,8 @@
 (ns kixi.hecuba.bootstrap
   (:require [om.core :as om :include-macros true]
             [om.dom :as dom :include-macros true]
-            [sablono.core :as html :refer-macros [html]]))
+            [sablono.core :as html :refer-macros [html]]
+            [cljs.core.async :refer [put!]]))
 
 
 (defn checkbox [v cursor on-click]
@@ -223,3 +224,12 @@
               :class "form-control"
               :type "text"
               :id "address_country"}]]]])
+
+(defn sorting-th [sort-spec th-chan label header-key]
+  (let [ {:keys [sort-key sort-asc]} sort-spec]
+    [:th {:onClick (fn [_ _] (put! th-chan header-key))}
+     (str label " ")
+     (if (= sort-key header-key)
+       (if sort-asc
+         [:i.fa.fa-sort-asc]
+         [:i.fa.fa-sort-desc]))]))

--- a/src-cljs/kixi/hecuba/model.cljs
+++ b/src-cljs/kixi/hecuba/model.cljs
@@ -12,6 +12,8 @@
     :programmes {:name     "Programmes"
                  :data     []
                  :selected nil
+                 :sort-spec {:sort-key :name
+                             :sort-asc true}
                  :editing false
                  :edited-row nil
                  :adding-programme false
@@ -19,12 +21,17 @@
     :projects {:name     "Projects"
                :data     []
                :selected nil
+               :sort-spec {:sort-key :name
+                           :sort-asc true}
                :editing false
                :edited-row nil
                :adding-project false}
     :properties {:name     "Properties"
                  :data     []
                  :selected nil
+                 :sort-spec {:sort-key :property_code
+                             :sort-fn :property_code
+                             :sort-asc true}
                  :adding-property false
                  :active-tab :overview
                  :alert {}
@@ -36,6 +43,8 @@
                                       :sort [:name]}
                            :alert {}
                            :selected nil
+                           :sort-spec {:sort-key :description
+                                       :sort-asc true}
                            :adding false
                            :editing false
                            :edited-device nil}
@@ -46,6 +55,8 @@
                                              :select   {:label "Select" :checkbox true}}
                                       :sort [:name]}
                            :selected nil
+                           :sort-spec {:sort-key :type
+                                       :sort-asc true}
                            :alert {}}
                  :datasets {:sensors []
                             :datasets []

--- a/src-cljs/kixi/hecuba/tabs/hierarchy/property_details.cljs
+++ b/src-cljs/kixi/hecuba/tabs/hierarchy/property_details.cljs
@@ -324,7 +324,8 @@
      (did-update [_ prev-props _]
        (when (and (or (not= (:selected prev-props) (:selected properties))
                       (not= (:data prev-props) (:data properties)))
-                  (-> properties :data seq))
+                  (-> properties :data seq)
+                  (-> properties :selected seq))
          (common/fixed-scroll-to-element "property-details")))
     om/IRenderState
     (render-state [_ state]


### PR DESCRIPTION
- Use global state to store sorting order (stops it from being reset
  between renders)
- Add sorting to programmes, projects and properties tables

Fixes #479 
