### PR TITLE
Workaround to use lifecycle protocols

### DIFF
--- a/src-cljs/kixi/hecuba/tabs/hierarchy/projects.cljs
+++ b/src-cljs/kixi/hecuba/tabs/hierarchy/projects.cljs
@@ -163,72 +163,76 @@
           [:td organisation]
           [:td project_code]])))))
 
-(defmulti projects-table
-  (fn [projects _ _]
-    (:fetching projects)))
+(defmulti projects-table  (fn [fetching] fetching))
 
-(defmethod projects-table :fetching [projects _ _]
-  (om/component
-   (html
-    (bs/fetching-row projects))))
+(defmethod projects-table :fetching [_]
+  (fn [projects owner opts]
+    (om/component
+     (html
+      (bs/fetching-row projects)))))
 
-(defmethod projects-table :no-data [projects _ _]
-  (om/component
-   (html
-    (bs/no-data-row projects))))
+(defmethod projects-table :no-data [_]
+  (fn [projects owner opts]
+    (om/component
+     (html
+      (bs/no-data-row projects)))))
 
-(defmethod projects-table :error [projects _ _]
-  (om/component
-   (html
-    (bs/error-row projects))))
+(defmethod projects-table :error [_]
+  (fn [projects owner opts]
+    (om/component
+     (html
+      (bs/error-row projects)))))
 
-(defmethod projects-table :has-data [projects owner {:keys [editing-chan]}]
-  (reify
-    om/IInitState
-    (init-state [_]
-      {:th-chan (chan)})
-    om/IWillMount
-    (will-mount [_]
-      (go-loop []
-        (let [{:keys [th-chan]}           (om/get-state owner)
-              sort-spec                   (:sort-spec @projects)
-              {:keys [sort-key sort-asc]} sort-spec
-              th-click                    (<! th-chan)]
-          (if (= th-click sort-key)
-            (om/update! projects :sort-spec {:sort-key th-click
-                                             :sort-asc (not sort-asc)})
-            (om/update! projects :sort-spec {:sort-key th-click
-                                             :sort-asc true})))
-        (recur)))
-    om/IRenderState
-    (render-state [_ state]
-      (html
-       (let [table-id   "projects-table"
-             history    (om/get-shared owner :history)
-             th-chan    (om/get-state owner :th-chan)
-             sort-spec  (:sort-spec projects)
-             {:keys [sort-key sort-asc]} sort-spec]
-         [:div.row
-          [:div.col-md-12
-           [:table {:className "table table-hover"}
-            [:thead
-             [:tr
-              (bs/sorting-th sort-spec th-chan "Name" :name)
-              (bs/sorting-th sort-spec th-chan "Type" :type)
-              (bs/sorting-th sort-spec th-chan "Organisation" :organisation)
-              (bs/sorting-th sort-spec th-chan "Project Code" :project_code)]]
-            [:tbody
-             (om/build-all project-row (if sort-asc
-                                         (sort-by sort-key (:data projects))
-                                         (reverse (sort-by sort-key (:data projects))))
-                           {:opts {:table-id table-id
-                                   :editing-chan editing-chan}
-                            :key :project_id})]]]])))))
+(defmethod projects-table :has-data [_]
+  (fn [projects owner {:keys [editing-chan]}]
+    (reify
+      om/IInitState
+      (init-state [_]
+        (log "has data init-state")
+        {:th-chan (chan)})
+      om/IWillMount
+      (will-mount [_]
+        (go-loop []
+          (let [{:keys [th-chan]}           (om/get-state owner)
+                sort-spec                   (:sort-spec @projects)
+                {:keys [sort-key sort-asc]} sort-spec
+                th-click                    (<! th-chan)]
+            (if (= th-click sort-key)
+              (om/update! projects :sort-spec {:sort-key th-click
+                                               :sort-asc (not sort-asc)})
+              (om/update! projects :sort-spec {:sort-key th-click
+                                               :sort-asc true})))
+          (recur)))
+      om/IRenderState
+      (render-state [_ state]
+        (html
+         (let [table-id   "projects-table"
+               history    (om/get-shared owner :history)
+               th-chan    (om/get-state owner :th-chan)
+               sort-spec  (:sort-spec projects)
+               {:keys [sort-key sort-asc]} sort-spec]
+           [:div.row
+            [:div.col-md-12
+             [:table {:className "table table-hover"}
+              [:thead
+               [:tr
+                (bs/sorting-th sort-spec th-chan "Name" :name)
+                (bs/sorting-th sort-spec th-chan "Type" :type)
+                (bs/sorting-th sort-spec th-chan "Organisation" :organisation)
+                (bs/sorting-th sort-spec th-chan "Project Code" :project_code)]]
+              [:tbody
+               (om/build-all project-row (if sort-asc
+                                           (sort-by sort-key (:data projects))
+                                           (reverse (sort-by sort-key (:data projects))))
+                             {:opts {:table-id table-id
+                                     :editing-chan editing-chan}
+                              :key :project_id})]]]]))))))
 
-(defmethod projects-table :default [_ _ _]
-  (om/component
-   (html
-    [:div.row [:div.col-md-12]])))
+(defmethod projects-table :default [_]
+  (fn [projects owner opts]
+    (om/component
+     (html
+      [:div.row [:div.col-md-12]]))))
 
 (defn projects-div [projects owner]
   (reify
@@ -275,7 +279,7 @@
               (om/build (project-edit-form projects refresh-chan) (-> projects :edited-row)))]
            [:div#projects-div
             (when-not (or editing adding-project)
-              (om/build projects-table projects {:opts {:editing-chan editing-chan}}))]
+              (om/build (projects-table (:fetching projects)) projects {:opts {:editing-chan editing-chan}}))]
            [:div#project-detail-div
             (when (and selected (not (or adding-project editing)))
               (om/build (project-detail projects editing-chan) selected-project))]]])))))

--- a/src-cljs/kixi/hecuba/tabs/hierarchy/properties.cljs
+++ b/src-cljs/kixi/hecuba/tabs/hierarchy/properties.cljs
@@ -138,71 +138,77 @@
 (defmethod sort-function :default [k]
   k)
 
-(defmulti properties-table (fn [properties owner] (:fetching properties)))
-(defmethod properties-table :fetching [properties owner]
-  (om/component
-   (html
-    (bs/fetching-row properties))))
+(defmulti properties-table (fn [fetching] fetching))
 
-(defmethod properties-table :no-data [properties owner]
-  (om/component
-   (html
-    (bs/no-data-row properties))))
+(defmethod properties-table :fetching [_]
+  (fn [properties owner]
+    (om/component
+     (html
+      (bs/fetching-row properties)))))
 
-(defmethod properties-table :error [properties owner]
-  (om/component
-   (html
-    (bs/error-row properties))))
+(defmethod properties-table :no-data [_]
+  (fn [properties owner]
+    (om/component
+     (html
+      (bs/no-data-row properties)))))
 
-(defmethod properties-table :has-data [properties owner]
-  (reify
-    om/IInitState
-    (init-state [_]
-      {:th-chan (chan)})
-    om/IWillMount
-    (will-mount [_]
-      (go-loop []
-        (let [{:keys [th-chan]}                   (om/get-state owner)
-              {:keys [sort-key sort-fn sort-asc]} (:sort-spec @properties)
-              th-click                            (<! th-chan)]
-          (if (= th-click sort-key)
-            (om/update! properties :sort-spec {:sort-key th-click
-                                                :sort-fn  (sort-function th-click)
-                                                :sort-asc (not sort-asc)})
-            (om/update! properties :sort-spec {:sort-key th-click
-                                                :sort-fn  (sort-function th-click)
-                                                :sort-asc true})))
-        (recur)))
-    om/IRenderState
-    (render-state [_ state]
-      (html
-       (let [table-id "properties-table"
-             history  (om/get-shared owner :history)
-             th-chan (:th-chan state)
-             {:keys [sort-spec]} properties
-             {:keys [sort-fn sort-asc]} (:sort-spec properties)]
-         [:div.col-md-12
-          [:table {:className "table table-hover"}
-           [:thead
-            [:tr
-             [:th "Photo"]
-             (bs/sorting-th sort-spec th-chan "Property Code" :property_code)
-             (bs/sorting-th sort-spec th-chan "Type" :property_type)
-             (bs/sorting-th sort-spec th-chan "Address" :address)
-             (bs/sorting-th sort-spec th-chan "Region" :region)
-             (bs/sorting-th sort-spec th-chan "Ownership" :ownership)
-             (bs/sorting-th sort-spec th-chan "Technologies" :technologies)
-             (bs/sorting-th sort-spec th-chan "Monitoring Hierarchy" :hierarchy)]]
-           [:tbody
-            (om/build-all property-row (if sort-asc
-                                         (sort-by sort-fn (:data properties))
-                                         (reverse (sort-by sort-fn (:data properties))))
-                          {:opts {:table-id table-id}})]]])))))
+(defmethod properties-table :error [_]
+  (fn [properties owner]
+    (om/component
+     (html
+      (bs/error-row properties)))))
 
-(defmethod properties-table :default [properties owner]
-  (om/component
-   (html
-    [:div.row [:div.col-md-12]])))
+(defmethod properties-table :has-data [_]
+  (fn [properties owner]
+    (reify
+      om/IInitState
+      (init-state [_]
+        {:th-chan (chan)})
+      om/IWillMount
+      (will-mount [_]
+        (go-loop []
+          (let [{:keys [th-chan]}                   (om/get-state owner)
+                {:keys [sort-key sort-fn sort-asc]} (:sort-spec @properties)
+                th-click                            (<! th-chan)]
+            (if (= th-click sort-key)
+              (om/update! properties :sort-spec {:sort-key th-click
+                                                 :sort-fn  (sort-function th-click)
+                                                 :sort-asc (not sort-asc)})
+              (om/update! properties :sort-spec {:sort-key th-click
+                                                 :sort-fn  (sort-function th-click)
+                                                 :sort-asc true})))
+          (recur)))
+      om/IRenderState
+      (render-state [_ state]
+        (html
+         (let [table-id "properties-table"
+               history  (om/get-shared owner :history)
+               th-chan (:th-chan state)
+               {:keys [sort-spec]} properties
+               {:keys [sort-fn sort-asc]} (:sort-spec properties)]
+           [:div.col-md-12
+            [:table {:className "table table-hover"}
+             [:thead
+              [:tr
+               [:th "Photo"]
+               (bs/sorting-th sort-spec th-chan "Property Code" :property_code)
+               (bs/sorting-th sort-spec th-chan "Type" :property_type)
+               (bs/sorting-th sort-spec th-chan "Address" :address)
+               (bs/sorting-th sort-spec th-chan "Region" :region)
+               (bs/sorting-th sort-spec th-chan "Ownership" :ownership)
+               (bs/sorting-th sort-spec th-chan "Technologies" :technologies)
+               (bs/sorting-th sort-spec th-chan "Monitoring Hierarchy" :hierarchy)]]
+             [:tbody
+              (om/build-all property-row (if sort-asc
+                                           (sort-by sort-fn (:data properties))
+                                           (reverse (sort-by sort-fn (:data properties))))
+                            {:opts {:table-id table-id}})]]]))))))
+
+(defmethod properties-table :default [_]
+  (fn [properties owner]
+    (om/component
+     (html
+      [:div.row [:div.col-md-12]]))))
 
 (defn properties-div [properties owner]
   (reify
@@ -232,4 +238,4 @@
            [:div {:id "property-add-div" :class (if adding-property "" "hidden")}
             (om/build (property-add-form properties refresh-chan project_id) nil)]
            [:div {:id "property-div" :class (if adding-property "hidden" "")}
-            (om/build properties-table properties)]]])))))
+            (om/build (properties-table (:fetching properties)) properties)]]])))))


### PR DESCRIPTION
Current implementation of Om doesn't respect life-cycle protocols.
This should be fixed with the next release of
Om (https://github.com/swannodette/om/issues/282). This commit is a
temporary solution.
