### PR TITLE
Filter entities according to user's permissions

### DIFF
--- a/elasticsearch/entities-mapping.json
+++ b/elasticsearch/entities-mapping.json
@@ -33,6 +33,9 @@
       "heating_type" : {
         "type" : "string"
       },
+      "location" : {
+        "type" : "boolean"
+      },
       "photovoltaics" : {
         "type" : "boolean"
       },

--- a/resources/site/css/hecuba.css
+++ b/resources/site/css/hecuba.css
@@ -196,3 +196,16 @@ div.last {
     -ms-overflow-style: -ms-autohiding-scrollbar;
     -webkit-overflow-scrolling: touch;
 }
+
+.container-popup {
+    min-width: 150px;
+    padding: 5px;
+    max-height: 100%;
+}
+
+.constrained {
+    width: 100%;
+    height: 100px;
+    display: inline-block;
+    max-width: 150px !important;
+}

--- a/resources/site/property_map.html
+++ b/resources/site/property_map.html
@@ -24,6 +24,7 @@
 
     <!-- Other 3rd Party -->
     <link href="/css/bootstrap-datetimepicker.css" rel="stylesheet" />
+    <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.6.2/leaflet.css" />
 
     <!-- Add custom CSS here -->
     <link href="/css/hecuba.css" rel="stylesheet">
@@ -62,7 +63,6 @@
   <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min.js"></script>
 
   <!-- leaflet -->
-  <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.6.2/leaflet.css" />
   <script src="//cdn.leafletjs.com/leaflet-0.6.2/leaflet.js"></script>
   <!--[if lte IE 8]>
   <link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.6.2/leaflet.ie.css" />

--- a/src/kixi/hecuba/api.clj
+++ b/src/kixi/hecuba/api.clj
@@ -188,3 +188,18 @@
 
 (defn headers-content-disposition [filename]
   {"Content-Disposition" (str "attachment; filename=" filename)})
+
+;; from https://github.com/weavejester/medley/blob/master/src/medley/core.cljx Thx @weavejester
+(defn dissoc-in
+  "Dissociate a value in a nested assocative structure, identified by a sequence
+of keys. Any collections left empty by the operation will be dissociated from
+their containing structures."
+  [m ks]
+  (if-let [[k & ks] (seq ks)]
+    (if (seq ks)
+      (let [v (dissoc-in (get m k) ks)]
+        (if (empty? v)
+          (dissoc m k)
+          (assoc m k v)))
+      (dissoc m k))
+    m))

--- a/src/kixi/hecuba/api/entities/property_map.clj
+++ b/src/kixi/hecuba/api/entities/property_map.clj
@@ -8,46 +8,128 @@
    [kixi.hecuba.storage.db :as db]
    [kixi.hecuba.data.programmes :as programmes]
    [kixi.hecuba.data.projects :as projects]
-   [kixi.hecuba.data.entities :as entities]))
+   [kixi.hecuba.data.entities :as entities]
+   [kixi.hecuba.data.entities.search :as search]
+   [clojurewerkz.elastisch.native.response :as esr]))
 
-(defn allowed?* [programme-id project-id allowed-programmes allowed-projects roles request-method]
-  (log/infof "allowed?* programme-id: %s project-id: %s allowed-programmes: %s allowed-projects: %s roles: %s request-method: %s"
-             programme-id project-id allowed-programmes allowed-projects roles request-method)
-  (match [(has-admin? roles)
-          (has-programme-manager? roles)
-          (some #(= % programme-id) allowed-programmes)
-          (has-project-manager? roles)
-          (some #(= % project-id) allowed-projects)
-          (has-user? roles)
-          request-method]
-         ;; super-admin - do everything
-         [true _ _ _ _ _ _] true
-         ;; programme-manager for this programme - do everything
-         [_ true true _ _ _ _] true
-         ;; project-manager for this project - do everything
-         [_ _ _ true true _ _] true
-         ;; user with this programme - get allowed
-         [_ _ true _ _ true :get] true
-         ;; user with this project - get allowed
-         [_ _ _ _ true true :get] true
+(def default-page-size 500)
+
+(defn remove-private-data [entity]
+  (if-not (:editable entity)
+      (-> entity
+          (api/dissoc-in [:property_data :address_street])
+          (api/dissoc-in [:property_data :address_street_two])
+          (api/dissoc-in [:property_data :address_city])
+          (api/dissoc-in [:property_data :address_code])
+          (api/dissoc-in [:property_data :fuel_poverty])
+          (assoc-in [:documents] (filter :public? (:documents entity)))
+          (dissoc :notes))
+      entity))
+
+(defn editable? [programme_id project_id allowed-programmes allowed-projects role]
+  (log/infof "editable? programme-id: %s project-id: %s allowed-programmes: %s allowed-projects: %s role: %s"
+             programme_id project_id allowed-programmes allowed-projects role)
+  (match [(has-admin? role)
+          (has-programme-manager? programme_id allowed-programmes)
+          (has-project-manager? project_id allowed-projects)
+          (has-user? programme_id allowed-programmes project_id allowed-projects)]
+
+         [true _ _ _] true
+         [_ true _ _] true
+         [_ _ true _] true
+         [_ _ _ true] false ;; atm I don't think the user on a programme or project can edit, just view
          :else false))
+
+(defn update-editable [e allowed-programmes allowed-projects role]
+  (update-in e [:full_entity] assoc :editable (editable? (:programme_id e) (:project_id e) allowed-programmes allowed-projects role)))
+
+(defn clean-entity
+  "Get rid of the keys that we don't want the user to see."
+  [entity file-bucket]
+  (-> entity
+      remove-private-data
+      (dissoc :user_id)
+      (api/enrich-media-uris file-bucket :photos)))
+
+(defn parse-entities [results allowed-programmes allowed-projects role file-bucket]
+  (->> results
+       esr/hits-from
+       (map :_source)
+       (map #(update-editable %  allowed-programmes allowed-projects role))
+       (map :full_entity)
+       (map #(clean-entity % file-bucket))))
+
+(defn should-terms [allowed-programmes allowed-projects]
+  (vec
+   (conj
+    (concat (map #(hash-map :term {:programme_id %}) (keys allowed-programmes))
+            (map #(hash-map :term {:project_id %}) (keys allowed-projects)))
+    {:term {:location true}}
+    {:term {:public_access "true"}})))
+
+(defn must-term [allowed-programmes allowed-projects]
+  (when (every? empty? [allowed-programmes allowed-projects])
+    {:term {:public_access "true"}}))
+
+(defn search-filter [must should must-not]
+  (let [shoulds (if must (conj (or should []) must) should)]
+    {:bool {:must (or must {})
+            :should shoulds
+            :must_not (or must-not {})}}))
+
+(defn filter-entities
+  ([params role store]
+     (let [query-string   (or (:q params) "*")
+           page-number    (or (:page params) 0)
+           page-size      (or (:size params) default-page-size)
+           from           (* page-number page-size)
+           results        (search/search-entities query-string from page-size (:search-session store))
+           total_hits     (esr/total-hits results)
+           file-bucket    (-> store :s3 :file-bucket)
+           parsed-results (parse-entities results nil nil role file-bucket)]
+       {:entities {:total_hits total_hits
+                   :page       page-number
+                   :entities   parsed-results}}))
+  ([params allowed-programmes allowed-projects role store]
+   (let [query-string   (or (:q params) "*")
+         page-number    (or (:page params) 0)
+         page-size      (or (:size params) default-page-size)
+         from           (* page-number page-size)
+         shoulds        (should-terms allowed-programmes allowed-projects)
+         filter-terms   (search-filter (must-term allowed-programmes allowed-projects) shoulds nil)
+         results        (search/search-entities query-string filter-terms from page-size (:search-session store))
+         total_hits     (esr/total-hits results)
+         file-bucket    (-> store :s3 :file-bucket)
+         parsed-results (parse-entities results allowed-programmes allowed-projects role file-bucket)]
+     {:entities {:total_hits total_hits
+                 :page       page-number
+                 :entities   parsed-results}})))
+
+(defn allowed?* [programmes projects role request-method params store]
+     ;; All entities
+     (log/infof "allowed?* allowed-programmes: %s allowed-projects: %s role: %s request-method: %s"
+                programmes projects role request-method)
+     (match [(has-admin? role)
+             request-method]
+
+            [true :get] [true {::items (filter-entities params role store)}]
+            [_    :get] [true {::items (filter-entities params programmes projects role store)}]
+            :else false))
 
 (defn index-allowed? [store]
   (fn [ctx]
     (let [{:keys [request-method session params]} (:request ctx)
-          {:keys [projects programmes roles]}     (sec/current-authentication session)
-          entity_id (:entity_id params)
-          project_id (when entity_id (:project_id (entities/get-by-id (:hecuba-session store) entity_id)))
+          {:keys [projects programmes role]}     (sec/current-authentication session)
+          entity_id    (:entity_id params)
+          project_id   (when entity_id (:project_id (entities/get-by-id (:hecuba-session store) entity_id)))
           programme_id (when project_id (:programme_id (projects/get-by-id (:hecuba-session store) project_id)))]
-      (if (and project_id programme_id)
-        (allowed?* programme_id project_id programmes projects roles request-method)
-        true))))
+      (allowed?* programmes projects role request-method params store))))
 
 (defn index-handle-ok [store ctx]
   (let [file-bucket (-> store :s3 :file-bucket)]
     (db/with-session [session (:hecuba-session store)]
-      (let [entities (->> (entities/get-entities-having-location session)
-                          (map #(api/enrich-media-uris % file-bucket :photos)))]
+      (let [items    (::items ctx)
+            entities (-> items :entities :entities)]
         {:entities entities}))))
 
 (defresource index [store]

--- a/src/kixi/hecuba/data/calculate.clj
+++ b/src/kixi/hecuba/data/calculate.clj
@@ -433,7 +433,7 @@
   ([store ds sensors range field]
      (let [{:keys [operation operands device_id entity_id]} ds
            operation   (keyword operation)
-           field-value (edn/read-string (get-field-value entity_id (keyword field) store))]
+           field-value (edn/read-string (str (get-field-value entity_id (keyword field) store)))]
        (log/info "Calculating datasets for operands: " operands "and operation: " operation "and range: " range)
        (let [measurements (mapcat #(measurements/parse-measurements
                                     (measurements/measurements-for-range store % range (t/hours 1))) sensors)]

--- a/src/kixi/hecuba/data/entities/search.clj
+++ b/src/kixi/hecuba/data/entities/search.clj
@@ -33,6 +33,9 @@
         (assoc :entity_id entity_id)
         (assoc :project_team project_team)
         (assoc :project_id project_id)
+        (assoc :location (and property_data
+                              (contains? property_data :latitude)
+                              (contains? property_data :longitude)))
 
         ;; filters
         (assoc :property_type property_type)


### PR DESCRIPTION
- Update tech icons
- Add location to ES fields
- Update map API to return filtered properties
- Require public access to be true if user's role is user and programmes and projects are empty maps.
- Fix incorrect url on pop-up's "view" link
- Fix technology icons
- Remove addresses when non-admin user
- Stringify fields stored in profiles that are selected for calculations, before attempting to use edn/read-string (some data seems to be inconsistent).
- Improve CSS for images displayed inside of pop-ups.

Fixes #514 
Fixes #511 
Fixes #512 
Fixes #513 
