### PR TITLE
Sortable search

### DIFF
--- a/elasticsearch/entities-mapping.json
+++ b/elasticsearch/entities-mapping.json
@@ -2,7 +2,12 @@
   "entity" : {
     "properties" : {
       "address" : {
-        "type" : "string"
+        "type" : "string",
+        "fields" : {
+            "lower_case_sort" : {
+                "type" : "string",
+                "analyzer" : "case_insensitive_sort"}
+        }
       },
       "address_region" : {
         "type" : "string"
@@ -43,12 +48,25 @@
         "type" : "string",
         "index" : "not_analyzed"
       },
+      "programme_name" : {
+         "type" : "string",
+         "fields" : {
+             "lower_case_sort" : {
+                 "type" : "string",
+                 "analyzer" : "case_insensitive_sort"}
+         }
+      },
       "project_id" : {
         "type" : "string",
         "index" : "not_analyzed"
       },
       "project_name" : {
-        "type" : "string"
+        "type" : "string",
+        "fields" : {
+            "lower_case_sort" : {
+                "type" : "string",
+                "analyzer" : "case_insensitive_sort"}
+        }
       },
       "project_organisation" : {
         "type" : "string"
@@ -57,7 +75,12 @@
         "type" : "string"
       },
       "property_code" : {
-        "type" : "string"
+        "type" : "string",
+        "fields" : {
+            "lower_case_sort" : {
+                "type" : "string",
+                "analyzer" : "case_insensitive_sort"}
+        }
       },
       "property_type" : {
         "type" : "string"

--- a/elasticsearch/entities.json
+++ b/elasticsearch/entities.json
@@ -1,3 +1,12 @@
 {
-  "settings" : {}
+    "settings" : {
+        "analysis": {
+            "analyzer": {
+                "case_insensitive_sort": {
+                    "tokenizer": "keyword",
+                    "filter":  [ "lowercase" ]
+                }
+            }
+        }
+    }
 }

--- a/src-cljs/kixi/hecuba/model.cljs
+++ b/src-cljs/kixi/hecuba/model.cljs
@@ -8,7 +8,9 @@
              :data []
              :selected nil
              :fetching false
-             :stats {}}
+             :stats {}
+             :sort-spec {:sort-key :programme_name
+                         :sort-asc true}}
     :programmes {:name     "Programmes"
                  :data     []
                  :selected nil

--- a/src-cljs/kixi/hecuba/tabs/hierarchy/data.cljs
+++ b/src-cljs/kixi/hecuba/tabs/hierarchy/data.cljs
@@ -285,15 +285,28 @@
                    (om/update! data [:properties :uploads :files] d))
         :headers {"Accept" "application/edn"}}))
 
-(defn search-properties [data page size query]
-  (log "Searching for: " query)
-  (om/update! data :fetching true)
-  (GET (str "/4/entities/?q=" (js/encodeURIComponent query) "&page=" page "&size=" size)
-       {:handler (fn [response]
-                   (let [entities (:entities response)]
-                     (om/update! data :data (into [] entities))
-                     (om/update! data :stats {:total_hits (:total_hits response)
-                                              :page (:page response)})
-                     (om/update! data :fetching false)))
-        :headers {"Accept" "application/edn"}
-        :response-format :text}))
+(defn search-properties
+  ([data page size query]
+   (log "Searching for: " query)
+   (om/update! data :fetching true)
+   (GET (str "/4/entities/?q=" (js/encodeURIComponent query) "&page=" page "&size=" size)
+        {:handler (fn [response]
+                    (let [entities (:entities response)]
+                      (om/update! data :data (into [] entities))
+                      (om/update! data :stats {:total_hits (:total_hits response)
+                                               :page (:page response)})
+                      (om/update! data :fetching false)))
+         :headers {"Accept" "application/edn"}
+         :response-format :text}))
+  ([data page size query sort]
+   (log "Searching for: " query "with sort: " sort)
+   (om/update! data :fetching true)
+   (GET (str "/4/entities/?q=" (js/encodeURIComponent query) "&page=" page "&size=" size sort)
+        {:handler (fn [response]
+                    (let [entities (:entities response)]
+                      (om/update! data :data (into [] entities))
+                      (om/update! data :stats {:total_hits (:total_hits response)
+                                               :page (:page response)})
+                      (om/update! data :fetching false)))
+         :headers {"Accept" "application/edn"}
+         :response-format :text})))

--- a/src/kixi/hecuba/api/entities.clj
+++ b/src/kixi/hecuba/api/entities.clj
@@ -102,7 +102,10 @@
            page-number    (or (:page params) 0)
            page-size      (or (:size params) default-page-size)
            from           (* page-number page-size)
-           results        (search/search-entities query-string from page-size (:search-session store))
+           {:keys [sort_key sort_order]} params
+           results        (if (and sort_key sort_order)
+                            (search/search-entities query-string from page-size sort_key sort_order (:search-session store))
+                            (search/search-entities query-string from page-size (:search-session store)))
            total_hits     (esr/total-hits results)
            file-bucket    (-> store :s3 :file-bucket)
            parsed-results (parse-entities results nil nil role file-bucket)]

--- a/src/kixi/hecuba/data/entities/search.clj
+++ b/src/kixi/hecuba/data/entities/search.clj
@@ -63,6 +63,7 @@
     (-> entity
         (assoc-in [:full_entity :programme_name] name)
         (assoc :public_access public_access)
+        (assoc :programme_name name)
         (assoc-in [:full_entity :public_access] public_access))))
 
 (defn profile-search-fields [entity db-session]
@@ -119,6 +120,15 @@
 
 ;; See http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html
 (defn search-entities
+  ([query-string from size sort-key sort-order search-session]
+   (search/search search-session
+                    "entities"
+                    "entity"
+                    :query {:query_string
+                            {:query query-string}}
+                    :size size
+                    :from from
+                    :sort {sort-key sort-order}))
   ([query-string filter-map from size search-session]
      (let [query {:query {:filtered
                           {:query


### PR DESCRIPTION
Sortable search:
- enable case insensitive sort (http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/sorting-collations.html) by updating settings and mappings
- Add programme_name to search keys
- Update UI to allow for search sort

MIGRATION:

Re-run `scripts/build-es-schema.sh` and `(kixi.hecuba.data.entities.search/refresh-search (:hecuba-session system) (:search-session system))`

Fixes #520 

![image](https://cloud.githubusercontent.com/assets/2522010/5297979/74ff1fd0-7bad-11e4-8b45-4345f86a5bfc.png)
