### PR TITLE
Load sensors tab when opening chart link.

### DIFF
--- a/src-cljs/kixi/hecuba/tabs/hierarchy.cljs
+++ b/src-cljs/kixi/hecuba/tabs/hierarchy.cljs
@@ -179,15 +179,19 @@
         (log "Setting selected sensors to: " sensors)
         (let [sensors-hashmap (into #{} (str/split sensors #";"))]
           (om/update! data [:properties :chart :sensors] sensors-hashmap)
-          (om/update! data [:properties :sensors :selected] sensors-hashmap)
-          ;; If sensors are selected, load sensors tab as default.
-          (when (-> @data :properties :chart :sensors seq)
-            (om/update! data [:properties :active-tab] :sensors))))
+          (om/update! data [:properties :sensors :selected] sensors-hashmap)))
 
       (when (or (not= start-date old-start-date)
                 (not= end-date old-end-date))
         (log "Setting date range to: " start-date end-date)
-        (om/update! data [:properties :chart :range] {:start-date start-date :end-date end-date}))
+        (om/update! data [:properties :chart :range] {:start-date start-date :end-date end-date})
+        ;; If sensors are selected and there's nothing in old history, load sensors tab as default
+        ;; and fetch measurements.
+        (when (and (-> @data :properties :chart :sensors seq)
+                   (empty? old-nav)
+                   start-date end-date properties)
+          (om/update! data [:properties :active-tab] :sensors)
+          (data/fetch-measurements (:properties data) properties (into #{} (str/split sensors #";")) start-date end-date)))
 
       (when (and programmes (seq (-> @data :programmes :data)))
         (let [selected-programme (first (filter #(= (:programme_id %) programmes) (-> @data :programmes :data)))]


### PR DESCRIPTION
If sensors are present in history, make sensors tab an active one.

Fixes #409 
