### PR TITLE
Add content-type 'text/csv' to headers

### DIFF
--- a/src/kixi/hecuba/api.clj
+++ b/src/kixi/hecuba/api.clj
@@ -187,7 +187,8 @@
     (assoc-in ctx [:representation :media-type] "text/csv")))
 
 (defn headers-content-disposition [filename]
-  {"Content-Disposition" (str "attachment; filename=" filename)})
+  {"Content-Disposition" (str "attachment; filename=" filename)
+   "Content-Type" "text/csv"})
 
 ;; from https://github.com/weavejester/medley/blob/master/src/medley/core.cljx Thx @weavejester
 (defn dissoc-in


### PR DESCRIPTION
Default content-type was `application/json`. Changing it to `text/csv` for attachments fixes issue in Safari.

Fixes #551 