### PR TITLE
Feature/dangerous years

### DIFF
--- a/src/clj/kixi/hecuba/data/measurements/upload.clj
+++ b/src/clj/kixi/hecuba/data/measurements/upload.clj
@@ -68,6 +68,7 @@
 (defn parse-header-rows [date-parser-fn rows]
   (let [invalid-date? (complement date-parser-fn)]
     (->> rows
+         (map #(map (fn [s] (str/trim s)) %)) ; trim each header field
          (take-while (comp invalid-date? first))
          (remove blank-row?))))
 

--- a/src/cljs/kixi/hecuba/widgets/measurementsupload.cljs
+++ b/src/cljs/kixi/hecuba/widgets/measurementsupload.cljs
@@ -9,7 +9,9 @@
                    {:display "dd-mm-yyyy hh:mm"    :format "dd-MM-yyyy HH:mm"}
                    {:display "yyyy/mm/dd hh:mm"    :format "yyyy/MM/dd HH:mm"}
                    {:display "yyyy-mm-dd hh:mm"    :format "yyyy-MM-dd HH:mm"}
-                   {:display "yyyy-mm-dd hh:mm:ss" :format "yyyy-MM-dd HH:mm:ss"}])
+                   {:display "yyyy-mm-dd hh:mm:ss" :format "yyyy-MM-dd HH:mm:ss"}
+                   {:display "dd/mm/yy hh:mm"      :format "dd/MM/yy HH:mm"}
+                   {:display "dd-mm-yy hh:mm"      :format "dd-MM-yy HH:mm"}])
 
 (defn validate-size-and-upload [uploads owner id url method]
   (if (not js/window.FileReader)


### PR DESCRIPTION
Added missing dangerous missing YY formats.

Trim header fields

Many header fields have hidden spaces that can cause problems when trying to match them up.

Fixes #589 
Fixes #590