### PR TITLE
Correct incorrect namespace.

### DIFF
--- a/src/clj/kixi/hecuba/controller/repl.clj
+++ b/src/clj/kixi/hecuba/controller/repl.clj
@@ -2,7 +2,7 @@
   "Useful functions for interacting with the pipeline from the repl."
   (:require [kixipipe.scheduler       :as s]
             [kixipipe.pipeline        :refer [submit-item shutdown-pipe]]
-            [kixi.application         :as kixi]))
+            [kixipipe.application     :as kixi]))
 
 (defmacro defreplmethods
   [name & options]


### PR DESCRIPTION
Not sure how this could ever have worked. Looks like a Schrödinbug to be.