### PR TITLE
Upgrade cljs deps & fix sorting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ pom.xml.asc
 *#
 .#*
 *~
+figwheel_server.log

--- a/env/dev/cljs/kixi/hecuba/dev.cljs
+++ b/env/dev/cljs/kixi/hecuba/dev.cljs
@@ -1,5 +1,5 @@
 (ns kixi.hecuba.env.dev
-  (:require [figwheel.client :as figwheel :include-macros true]
+  (:require [figwheel.client :as figwheel]
             [kixi.hecuba.main :as m]))
 
 

--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,7 @@
 
                  ;; liberator
                  [org.clojure/tools.trace "0.7.8"]
-                 [compojure "1.1.8"]
+                 [compojure "1.3.2"]
                  [liberator "0.12.2"]
 
                  ;; Data
@@ -70,7 +70,7 @@
 
                  ;; ClojureScript dependencies
 
-                 [org.clojure/clojurescript "0.0-2755" :scope "provided"]
+                 [org.clojure/clojurescript "0.0-2843" :scope "provided"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha" :scope "provided"]
 
                  [cljs-ajax "0.2.3"]
@@ -80,7 +80,7 @@
                  [sablono "0.2.22"]
 
                  ;; Dev environment
-                 [lein-figwheel "0.1.5-SNAPSHOT"]
+                 [lein-figwheel "0.2.5"]
                  [enlive "1.1.5"]
                  [environ "1.0.0"]
                  [ankha "0.1.4"]
@@ -111,13 +111,18 @@
 
   :profiles {:dev {:source-paths ["dev"]
                    :dependencies [[ring-mock "0.1.5"]
+                                  [figwheel "0.2.5"]
+                                  [figwheel-sidecar "0.2.5"]
+                                  [com.cemerick/piggieback "0.1.5"]
+                                  [weasel "0.6.0"]
                                   [org.clojure/tools.namespace "0.2.5"]
                                   [org.clojure/test.check "0.5.9"]]
                    :figwheel {:http-server-root "cljs"
                               :port 3449
                               :css-dirs ["resources/site/css"]}
                    :env {:is-dev true}
-                   :plugins [[lein-figwheel "0.1.5-SNAPSHOT"]]}
+                   :plugins [[lein-figwheel "0.2.5"]]
+                   :cljsbuild {:builds {:hecuba {:source-paths ["env/dev/cljs" "src/cljs"]}}}}
              :uberjar {:hooks [leiningen.cljsbuild]
                        :env {:production true}
                        :main kixi.hecuba.main
@@ -139,7 +144,6 @@
   :cljsbuild {:builds {:hecuba {:source-paths ["src/cljs" "env/prod/cljs" "env/dev/cljs"]
                                 :jar true
                                 :compiler {:output-to "out/cljs/hecuba.js"
-                                           :source-map "out/cljs/hecuba.map.js"
                                            :output-dir "out/cljs"
                                            :optimizations :none
                                            :pretty-print true}}
@@ -147,7 +151,7 @@
                               :compiler {:output-to "target/testable.js"
                                          :preamble ["react/react.min.js" "vendor/d3.v3.min.js"]
                                          :optimizations :whitespace
-                                         :pretty-print  true}}}
+                                         :pretty-print  false}}}
               :test-commands {"test" ["phantomjs" "phantom/unit-test.js" "phantom/unit-test.html"]}}
 
   ;; lein test - runs default

--- a/src/cljs/kixi/hecuba/bootstrap.cljs
+++ b/src/cljs/kixi/hecuba/bootstrap.cljs
@@ -5,16 +5,6 @@
             [cljs.core.async :refer [put!]]
             [kixi.hecuba.tabs.slugs :as slugs]))
 
-
-(defn checkbox [v cursor on-click]
-  (dom/div
-   #js {:className "checkbox"
-        ;; TODO hack alert!!
-        :style {:margin 0}}
-   (dom/label #js {:className "checkbox-inline"}
-              (dom/input #js {:type "checkbox"
-                              :value v
-                              :onClick on-click}))))
 (defn button
   ([text kind dismiss]
      (button text kind dismiss nil))

--- a/src/cljs/kixi/hecuba/tabs/hierarchy.cljs
+++ b/src/cljs/kixi/hecuba/tabs/hierarchy.cljs
@@ -273,7 +273,9 @@
             [:button {:type "button"
                       :class "btn btn-primary"
                       :onClick (fn [_]
-                                 (data/search-properties cursor 0 10 (:term @cursor)))}
+                                 (let [{:keys [sort-key sort-asc]} (:sort-spec @cursor)]
+                                   (data/search-properties cursor 0 10 (:term @cursor)
+                                                           (get-sort-str sort-key sort-asc))))}
              [:span.glyphicon.glyphicon-search]]]]])))))
 
 (defn found-property-row [cursor owner]


### PR DESCRIPTION
Fixes #598 

This PR upgrades:
- ClojureScript, though not to the latest version as the latest version requires newest Guava `18.0`, but DataStax Cassandra driver overrides it to `14.0.1` to remain compatible with `Spark 1.1`.
- Figwheel
- Compojure

It also fixes an issue where all consecutive searches using ES were not sorted.