### PR TITLE
Time series with and without standing charges.

### DIFF
--- a/src/clj/kixi/hecuba/api/datasets.clj
+++ b/src/clj/kixi/hecuba/api/datasets.clj
@@ -215,6 +215,10 @@
   (let [{:keys [sensors operands]} item
         [field unit] (string/split (last operands) #"~")]
     (str (:unit (first sensors)) "/" unit)))
+(defmethod get-unit :tariff-calculation-with-standing-charges [item]
+  "£")
+(defmethod get-unit :tariff-calculation-without-standing-charges [item]
+  "£")
 (defmethod get-unit :default [item]
   (:unit (first (:sensors item))))
 

--- a/src/clj/kixi/hecuba/api/datasets.clj
+++ b/src/clj/kixi/hecuba/api/datasets.clj
@@ -126,7 +126,8 @@
                   {:keys [operation]} body]
               (if (some #{operation} ["divide" "sum" "subtract" "multiply-series-by-field"
                                       "divide-series-by-field" "total-usage-weekly" "total-usage-monthly"
-                                      "tariff-calculation"
+                                      "tariff-calculation-with-standing-charges"
+                                      "tariff-calculation-without-standing-charges"
                                       "min-for-day" "min-for-day-morning" "min-for-day-day" "min-for-day-afteroon"
                                       "min-for-day-night" "avg-for-day" "avg-for-day-morning" "avg-for-day-day"
                                       "avg-for-day-evening" "avg-for-day-night" "max-for-day" "max-for-day-morning"

--- a/src/clj/kixi/hecuba/controller/pipeline.clj
+++ b/src/clj/kixi/hecuba/controller/pipeline.clj
@@ -240,7 +240,9 @@
       (mc/total-usage-calculation store item))
     (defmethod synthetic-readings :total-usage-monthly [store item]
       (mc/total-usage-calculation store item))
-    (defmethod synthetic-readings :tariff-calculation [store item]
+    (defmethod synthetic-readings :tariff-calculation-with-standing-charges [store item]
+      (mc/expenditure-calculation-raw store item))
+    (defmethod synthetic-readings :tariff-calculation-without-standing-charges [store item]
       (mc/expenditure-calculation-raw store item))
     (defmethod synthetic-readings :min-for-day [store item]
       (mc/reading-for-a-day store item))
@@ -318,7 +320,7 @@
         (datasets/sensors-for-dataset {:operands (take 1 operands)} store)))
     (defmethod sensors-for-dataset :default [ds store]
       (let [{:keys [operands]} ds]
-        (first (datasets/sensors-for-dataset ds store))))
+        (datasets/sensors-for-dataset ds store)))
 
     (defnconsumer synthetic-readings-q [item]
       (log/info "Starting synthetic readings job.")

--- a/src/cljs/kixi/hecuba/tabs/hierarchy/datasets.cljs
+++ b/src/cljs/kixi/hecuba/tabs/hierarchy/datasets.cljs
@@ -118,7 +118,9 @@
                            {:display "Select operation"                            :value "none"}
                            {:display "Total usage - weekly"                        :value "total-usage-weekly"}
                            {:display "Total usage - monthly"                       :value "total-usage-monthly"}
-                           {:display "Tariff calculation"                          :value "tariff-calculation"}
+                           {:display "Tariff calculation - with standing charges"  :value "tariff-calculation-with-standing-charges"}
+                           {:display "Tariff calculation - without standing charges"
+                            :value "tariff-calculation-without-standing-charges"}
                            {:display "Minimum value for a day"                     :value "min-for-day"}
                            {:display "Minimum value for a day - morning"           :value "min-for-day-morning"}
                            {:display "Minimum value for a day - day"               :value "min-for-day-day"}

--- a/test/clj/kixi/hecuba/data/measurements/calculations_test.clj
+++ b/test/clj/kixi/hecuba/data/measurements/calculations_test.clj
@@ -136,7 +136,7 @@
 (deftest apply-tariff-test
   (testing "Testing calculation of standard tariff."
     (is (= 0.08
-           (calculate/round (apply-tariff {:cost-per-kwh 0.13 :type :electricity :daily-standing-charge 0.2192
+           (calculate/round (apply-tariff {:cost_per_kwh 0.13 :type :electricity :daily_standing_charge 0.2192
                                            :annual-lump-sum-discount 5.0}
                                           [{:device_id "aa8392871e0f0a5dc23fb1f89f58b765d85674aa",
                                             :sensor_id "Electricity consumption_differenceSeries",
@@ -172,15 +172,16 @@
                                             :timestamp #inst "2013-09-28T20:30:00.000-00:00",
                                             :error nil,
                                             :reading_metadata {"is-number" "true", "median-spike" "n-a"},
-                                            :value "0.02"}])
+                                            :value "0.02"}]
+                                          :tariff-calculation-without-standing-charges)
                             2)))
-    (is (= 0.06
+    (is (= 0.25
            (calculate/round (apply-tariff {:type "electricity_time_of_use"
-                                           :daily-standing-charge 0.2192
-                                           :cost-per-on-peak-kwh 0.15
-                                           :cost-per-off-peak-kwh 0.06
-                                           :annual-lump-sum-discount 10.0
-                                           :off-peak-periods [{:start "00:00" :end "05:00"}
+                                           :daily_standing_charge 0.2192
+                                           :cost_per_on_peak_kwh 0.15
+                                           :cost_per_off_peak_kwh 0.06
+                                           :annual_lump_sum_discount 10.0
+                                           :off_peak_periods [{:start "00:00" :end "05:00"}
                                                               {:start "22:00" :end "23:59"}]}
                                           [{:device_id "aa8392871e0f0a5dc23fb1f89f58b765d85674aa",
                                             :sensor_id "Electricity consumption_differenceSeries",
@@ -216,7 +217,8 @@
                                             :timestamp #inst "2013-09-28T05:30:00.000-00:00",
                                             :error nil,
                                             :reading_metadata {"is-number" "true", "median-spike" "n-a"},
-                                            :value "0.02"}])
+                                            :value "0.02"}]
+                                          :tariff-calculation-with-standing-charges)
                             2)))))
 
 (deftest day->on-off-periods-test


### PR DESCRIPTION
This PR separates tariff calculation into time series with and without standing charges.

Tariff information is coming from `profile_data` in Cassandra and is therefore snake cased.

![image](https://cloud.githubusercontent.com/assets/2522010/7352548/4d2b4c0e-ed04-11e4-8e14-d039319f971c.png)
 