### PR TITLE
Fixed a bug in etl data generation (entities payload has changed)

### DIFF
--- a/dev/etl.clj
+++ b/dev/etl.clj
@@ -72,8 +72,9 @@
         ;; ENTITY
         entity                {:project_id project_id
                                :property_code "1a2b3c4d"}
-        entity_url            (:location (read-response (post-resource (str hostname "/4/entities/")
-                                                                       "application/json" entity)))
+        entity_url            (:location (:body (read-response (post-resource (str hostname "/4/entities/")
+                                                                       "application/json" entity))))
+        _ (log/error ">>>>>>" entity_url)
         [_ _ _ entity_id]     (string/split entity_url #"/")
         ;; DEVICE
         device                {:description "External air temperature sensor"

--- a/dev/etl.clj
+++ b/dev/etl.clj
@@ -74,7 +74,6 @@
                                :property_code "1a2b3c4d"}
         entity_url            (:location (:body (read-response (post-resource (str hostname "/4/entities/")
                                                                        "application/json" entity))))
-        _ (log/error ">>>>>>" entity_url)
         [_ _ _ entity_id]     (string/split entity_url #"/")
         ;; DEVICE
         device                {:description "External air temperature sensor"


### PR DESCRIPTION
At some point the entities response payload has changed and now the `:location` key is nested inside the `:body` key.