### PR TITLE
Fix rollup calculations

### DIFF
--- a/src/clj/kixi/hecuba/data/calculate.clj
+++ b/src/clj/kixi/hecuba/data/calculate.clj
@@ -238,9 +238,9 @@
                                                      :year (time/get-year-partition-key start-date)
                                                      :device_id device_id
                                                      :sensor_id sensor_id}))))
-        (catch Exception e (log/error (str "Roll up failed on sensor_id " sensor_id " " start-date))))
-      
+        (catch Throwable e (log/errorf e "Roll up failed on device_id %s sensor_id %s start-date %s" device_id sensor_id  start-date)))      
       end-date)))
+
 
 (defn hourly-rollups
   "Calculates hourly rollups for given sensor and date range.

--- a/src/clj/kixi/hecuba/data/calculate.clj
+++ b/src/clj/kixi/hecuba/data/calculate.clj
@@ -238,7 +238,7 @@
                                                      :year (time/get-year-partition-key start-date)
                                                      :device_id device_id
                                                      :sensor_id sensor_id}))))
-        (catch Exception e (prn "Roll up failed, does sensor exist?")))
+        (catch Exception e (log/error (str "Roll up failed on sensor_id " sensor_id " " start-date))))
       
       end-date)))
 

--- a/src/clj/kixi/hecuba/data/calculate.clj
+++ b/src/clj/kixi/hecuba/data/calculate.clj
@@ -229,14 +229,17 @@
                                             "CUMULATIVE" (last measurements)
                                             "INSTANT"    (average-reading measurements)
                                             "PULSE"      (reduce + measurements)))]
-      (when-let [filtered (data-to-calculate? measurements)]
-        (db/execute session
-                    (hayt/insert :hourly_rollups (hayt/values
-                                                  {:value (str (round (funct filtered)))
-                                                   :timestamp (tc/to-date end-date)
-                                                   :year (time/get-year-partition-key start-date)
-                                                   :device_id device_id
-                                                   :sensor_id sensor_id}))))
+      (try 
+        (when-let [filtered (data-to-calculate? measurements)]
+          (db/execute session
+                      (hayt/insert :hourly_rollups (hayt/values
+                                                    {:value (str (round (funct filtered)))
+                                                     :timestamp (tc/to-date end-date)
+                                                     :year (time/get-year-partition-key start-date)
+                                                     :device_id device_id
+                                                     :sensor_id sensor_id}))))
+        (catch Exception e (prn "Roll up failed, does sensor exist?")))
+      
       end-date)))
 
 (defn hourly-rollups

--- a/src/clj/kixi/hecuba/data/measurements.clj
+++ b/src/clj/kixi/hecuba/data/measurements.clj
@@ -209,11 +209,9 @@
                                    (try 
                                      (Double/valueOf (:value m))
                                      (catch NumberFormatException e nil
-                                            (log/error e
-                                                       (str "> NumberFormatException in parse-measurements - sensor_id: " (:sensor_id m) " " (:timestamp m))))
+                                            (log/errorf e "> NumberFormatException in parse-measurements - %s %s [%s] " (:sensor_id m) (:timestamp m) (:value m)))
                                      (catch NullPointerException e nil
-                                            (log/error e
-                                                       (str "> NumberFormatException in parse-measurements - sensor_id: " (:sensor_id m) " " (:timestamp m))))))] 
+                                            (log/errorf e "> NumberFormatException in parse-measurements - %s %s [%s] " (:sensor_id m) (:timestamp m) (:value m)))))] 
                            (if (number? n)
                              n
                              nil))))

--- a/src/clj/kixi/hecuba/data/measurements.clj
+++ b/src/clj/kixi/hecuba/data/measurements.clj
@@ -204,7 +204,16 @@
    Returns a list of maps, with all values parsed approprietly."
   [measurements]
   (map (fn [m] (assoc-in m [:value]
-                         (let [n (edn/read-string (:value m))]
+                         (let [n (if (number? (:value m)) 
+                                   (:value m)
+                                   (try 
+                                     (Double/valueOf (:value m))
+                                     (catch NumberFormatException e nil
+                                            (log/error e
+                                                       "> NumberFormatException in parse-measurements"))
+                                     (catch NullPointerException e nil
+                                            (log/error e
+                                                       "> NumberFormatException in parse-measurements"))))] 
                            (if (number? n)
                              n
                              nil))))

--- a/src/clj/kixi/hecuba/data/measurements.clj
+++ b/src/clj/kixi/hecuba/data/measurements.clj
@@ -210,10 +210,10 @@
                                      (Double/valueOf (:value m))
                                      (catch NumberFormatException e nil
                                             (log/error e
-                                                       "> NumberFormatException in parse-measurements"))
+                                                       (str "> NumberFormatException in parse-measurements - sensor_id: " (:sensor_id m) " " (:timestamp m))))
                                      (catch NullPointerException e nil
                                             (log/error e
-                                                       "> NumberFormatException in parse-measurements"))))] 
+                                                       (str "> NumberFormatException in parse-measurements - sensor_id: " (:sensor_id m) " " (:timestamp m))))))] 
                            (if (number? n)
                              n
                              nil))))

--- a/test/clj/kixi/hecuba/data/calculate_test.clj
+++ b/test/clj/kixi/hecuba/data/calculate_test.clj
@@ -75,35 +75,35 @@
     (println "Testing compute-datasets.")
 
     (testing "Testing addition"
-      (is (= "0"   (:value (first (apply calc/compute-datasets :sum "12345" "temperature" measurements)))))
-      (is (= "2"   (:value (second (apply calc/compute-datasets :sum "12345" "temperature" measurements)))))
-      (is (= "998" (:value (last (apply calc/compute-datasets :sum "12345" "temperature" measurements)))))
-      (is (= "499" (:value (first (calc/compute-datasets :sum "12345" "temperature"
+      (is (= "0.0" (:value (first (apply calc/compute-datasets :sum "12345" "temperature" measurements)))))
+      (is (= "2.0" (:value (second (apply calc/compute-datasets :sum "12345" "temperature" measurements)))))
+      (is (= "998.0" (:value (last (apply calc/compute-datasets :sum "12345" "temperature" measurements)))))
+      (is (= "499.0" (:value (first (calc/compute-datasets :sum "12345" "temperature"
                                                          (first measurements)
                                                          (reverse (last measurements))))))))
 
     (testing "Testing subtraction"
-      (is (= "0"    (:value (first (apply calc/compute-datasets :subtract "12345" "temperature" measurements)))))
-      (is (= "0"    (:value (second (apply calc/compute-datasets :subtract "12345" "temperature" measurements)))))
-      (is (= "0"    (:value (last (apply calc/compute-datasets :subtract "12345" "temperature" measurements)))))
-      (is (= "-499" (:value (first (calc/compute-datasets :subtract "12345" "temperature"
+      (is (= "0.0"    (:value (first (apply calc/compute-datasets :subtract "12345" "temperature" measurements)))))
+      (is (= "0.0"    (:value (second (apply calc/compute-datasets :subtract "12345" "temperature" measurements)))))
+      (is (= "0.0"    (:value (last (apply calc/compute-datasets :subtract "12345" "temperature" measurements)))))
+      (is (= "-499.0" (:value (first (calc/compute-datasets :subtract "12345" "temperature"
                                                           (first measurements)
                                                           (reverse (last measurements))))))))
 
     (testing "Testing division"
       (is (= "N/A"  (:value (first (apply calc/compute-datasets :divide "12345" "temperature" measurements)))))
-      (is (= "1"    (:value (second (apply calc/compute-datasets :divide "12345" "temperature" measurements)))))
-      (is (= "1"    (:value (last (apply calc/compute-datasets :divide "12345" "temperature" measurements)))))
-      (is (= "0"    (:value (first (calc/compute-datasets :divide "12345" "temperature"
+      (is (= "1.0"    (:value (second (apply calc/compute-datasets :divide "12345" "temperature" measurements)))))
+      (is (= "1.0"    (:value (last (apply calc/compute-datasets :divide "12345" "temperature" measurements)))))
+      (is (= "0.0"    (:value (first (calc/compute-datasets :divide "12345" "temperature"
                                                           (first measurements)
                                                           (reverse (last measurements)))))))
       (is (= "N/A"  (:value (first (calc/compute-datasets :divide "12345" "temperature"
                                                           (reverse (last measurements))
                                                           (first measurements)))))))
     (testing "Testing multiplication"
-      (is (= "0"      (:value (first (apply calc/compute-datasets :multiply "12345" "temperature" measurements)))))
-      (is (= "1"      (:value (second (apply calc/compute-datasets :multiply "12345" "temperature" measurements)))))
-      (is (= "249001" (:value (last (apply calc/compute-datasets :multiply "12345" "temperature" measurements)))))
+      (is (= "0.0"      (:value (first (apply calc/compute-datasets :multiply "12345" "temperature" measurements)))))
+      (is (= "1.0"      (:value (second (apply calc/compute-datasets :multiply "12345" "temperature" measurements)))))
+      (is (= "249001.0" (:value (last (apply calc/compute-datasets :multiply "12345" "temperature" measurements)))))
       (is (= "N/A" (:value (nth (apply calc/compute-datasets :multiply "12345" "temperature" invalid-measurements) 5)))))))
 
 (deftest diff-seq-test

--- a/test/clj/kixi/hecuba/data/measurements/calculations_test.clj
+++ b/test/clj/kixi/hecuba/data/measurements/calculations_test.clj
@@ -10,10 +10,10 @@
 
 (deftest calculate-reading-from-seq-test
   (testing "It returns the minimum value for a sequence of sensor data."
-    (is (= 0
+    (is (== 0
            (calculate-reading-from-seq min-value
                                        (take 10 (g/generate-measurements (g/generate-sensor-sample "CUMULATIVE"))))))
-    (is (= 1
+    (is (== 1
            (calculate-reading-from-seq min-value
                                        [{:error nil, :reading_metadata {"is-number" "false"}, :value "Invalid reading", :type "temperatureGround",
                                          :timestamp #inst "2014-01-01T00:00:00.000-00:00"}
@@ -38,17 +38,17 @@
                  :timestamp #inst "2014-01-01T00:30:00.000-00:00"}
                 {:reading_metadata {"is-number" "true"}, :error nil, :value "1", :type "temperatureGround",
                  :timestamp #inst "2014-01-01T00:45:00.000-00:00"}]]
-      (is (= 1 (calculation :min-for-day data)))
-      (is (= 3 (calculation :max-for-day data)))
-      (is (= 2.0 (calculation :avg-for-day data)))
-      (is (= 1 (calculation :min-rolling-4-weeks data)))
-      (is (= 3 (calculation :max-rolling-4-weeks data)))
-      (is (= 2.0 (calculation :avg-rolling-4-weeks data)))
+      (is (== 1 (calculation :min-for-day data)))
+      (is (== 3 (calculation :max-for-day data)))
+      (is (== 2.0 (calculation :avg-for-day data)))
+      (is (== 1 (calculation :min-rolling-4-weeks data)))
+      (is (== 3 (calculation :max-rolling-4-weeks data)))
+      (is (== 2.0 (calculation :avg-rolling-4-weeks data)))
       (is (nil? (calculation :min-for-day [])))
       (is (nil? (calculation :max-for-day nil)))
-      (is (= 2.0 (calculation :avg-rolling-4-weeks-night data)))
-      (is (= 0 (calculation :min-rolling-4-weeks-night (g/generate-measurements (g/generate-sensor-sample "CUMULATIVE")))))
-      (is (= 499 (calculation :max-rolling-4-weeks-night (g/generate-measurements (g/generate-sensor-sample "CUMULATIVE")))))
+      (is (== 2.0 (calculation :avg-rolling-4-weeks-night data)))
+      (is (== 0 (calculation :min-rolling-4-weeks-night (g/generate-measurements (g/generate-sensor-sample "CUMULATIVE")))))
+      (is (== 499 (calculation :max-rolling-4-weeks-night (g/generate-measurements (g/generate-sensor-sample "CUMULATIVE")))))
       (is (= 134.5 (calculation :avg-rolling-4-weeks-night (g/generate-measurements (g/generate-sensor-sample "CUMULATIVE"))))))))
 
 (deftest filter-test

--- a/test/clj/kixi/hecuba/data/measurements_test.clj
+++ b/test/clj/kixi/hecuba/data/measurements_test.clj
@@ -8,3 +8,27 @@
                  [= :month 201101] [>= :timestamp 20140101] [< :timestamp 20140201]])
            (set (where {:device_id "12345" :sensor_id "6789"
                         :month 201101 :start 20140101 :end 20140201}))))))
+
+(deftest parse-measurements-test
+  (testing "Testing conversion of measurement map values to number values"
+    ;; Testing string and number values
+    (is (= '({:type "thing", :timestamp "2015-01-01 00:00:00", :value 0.192}
+             {:type "thing", :timestamp "2015-01-01 01:00:00", :value 0.2992}
+             {:type "thing", :timestamp "2015-01-01 02:00:00", :value 1.989})
+           (parse-measurements [{:type "thing", :timestamp "2015-01-01 00:00:00", :value "0.192"}
+                                {:type "thing", :timestamp "2015-01-01 01:00:00", :value "0.2992"}
+                                {:type "thing", :timestamp "2015-01-01 02:00:00", :value 1.989}])))
+    ;; Testing string or number values with a leading zero
+    (is  (= '({:type "thing", :timestamp "2015-01-01 00:00:00", :value 0.192}
+              {:type "thing", :timestamp "2015-01-01 01:00:00", :value 9.2992}
+              {:type "thing", :timestamp "2015-01-01 02:00:00", :value 1.989})
+            (parse-measurements [{:type "thing" :timestamp "2015-01-01 00:00:00" :value "0.192"}
+                                 {:type "thing" :timestamp "2015-01-01 01:00:00" :value "09.2992"}
+                                 {:type "thing" :timestamp "2015-01-01 02:00:00" :value 01.989}])))
+    ;; Testing nil value and random string value
+    (is (= '({:type "thing", :timestamp "2015-01-01 00:00:00", :value 0.192}
+             {:type "thing", :timestamp "2015-01-01 01:00:00", :value nil}
+             {:type "thing", :timestamp "2015-01-01 02:00:00", :value nil})
+           (parse-measurements [{:type "thing" :timestamp "2015-01-01 00:00:00" :value "0.192"}
+                                {:type "thing" :timestamp "2015-01-01 01:00:00" :value nil}
+                                {:type "thing" :timestamp "2015-01-01 02:00:00" :value "wibble"}])))))


### PR DESCRIPTION
Fixing the rollups errors:

-> Files modified: 
* src/clj/kixi/hecuba/data/measurements.clj
* test/clj/kixi/hecuba/data/measurements_test.clj
* test/clj/kixi/hecuba/data/calculate_test.clj
* test/clj/kixi/hecuba/data/measurements/calculations_test.clj

-> Exceptions found on the server: https://gist.github.com/Eleonore9/f747540d919f6f1a8fde#file-log-dse00-18092015-rollups
-> Format error linked to issue #649 
-> We replaced `edn/read-string` with `Double/valueOf`
-> It now has to be tested