### PR TITLE
Remove `nil`s from the sensors readings

### DIFF
--- a/src/clj/kixi/hecuba/api/devices.clj
+++ b/src/clj/kixi/hecuba/api/devices.clj
@@ -126,7 +126,8 @@
        (mapcat (fn [sensor]
                  (if (= "PULSE" (:period sensor))
                    [sensor (calculated-sensor sensor)] [sensor])))
-       flatten))
+       flatten
+       (keep identity)))
 
 (defn create-default-sensors
   "Creates default sensors whenever new device is added: *_differenceSeries for CUMULATIVE,


### PR DESCRIPTION
While testing I had a 500 error due to a `nil` in my readings:

```
{:description device007-2, :entity_id 0209d8ca-36f1-45ee-8fdb-d17a69473d6a, :privacy , 
:readings [{:type electricityConsumption, :period CUMULATIVE, :unit Kw, 
:sensor_id b192319d-232c-4a3f-a04c-595005f1f169} {:type electricityConsumption_differenceSeries, 
:period PULSE, :unit Kw, :sensor_id 5e6778dc-692a-41e9-b986-c50496e6f086, :synthetic true} 
nil]}
```