### PR TITLE
Fix `encode` for sensor metadata update + tests

### DIFF
--- a/src/clj/kixi/hecuba/data/sensors.clj
+++ b/src/clj/kixi/hecuba/data/sensors.clj
@@ -174,8 +174,10 @@
        (cond-> (not-empty  (:alias_sensor sensor))
          (assoc :alias_sensor {"sensor_id" (get-in sensor [:alias_sensor :sensor_id])
                                "device_id" (get-in sensor [:alias_sensor :device_id])}))
-       (cond-> (empty? (:alias_sensor sensor))
-         (assoc :alias_sensor {})))))
+       (cond-> (and (contains? sensor :alias_sensor) (empty? (:alias_sensor sensor)))
+         (assoc :alias_sensor {}))
+       (cond-> (not (contains? sensor :alias_sensor))
+         identity))))
 
 
 (defn sensor-time-range [sensor session]


### PR DESCRIPTION
`Sensor_metadata` table doesn't have a `alias_sensor` column.
When updating sensor metadata in the `encode` function we shouldn't assoc `:alias_sensor {}` in that case.

I also added 3 tests for cases I know about.