### PR TITLE
Feature/debug rollups insert fail

### DIFF
--- a/test/clj/kixi/hecuba/data/measurements_test.clj
+++ b/test/clj/kixi/hecuba/data/measurements_test.clj
@@ -1,6 +1,63 @@
 (ns kixi.hecuba.data.measurements-test
   (:require [kixi.hecuba.data.measurements :refer :all]
-            [clojure.test :refer :all]))
+            [clojure.test                  :refer :all]
+            [kixi.hecuba.data.calculate    :as calc]
+            [generators                    :as g]))
+
+;; Make sure the query for rollups to insert data into partitioned_measurement
+;; is formatted correctly and doesn't lead to an error
+(deftest prepare-batch-test
+  (testing "Testing the queries are formatted correctly"
+    (let [sensor (first (g/generate-sensor-sample "CUMULATIVE" 1))
+          measurements        (g/measurements sensor)
+          calc-measurements   (calc/diff-seq "12345" measurements)
+          batch-measurements  (first (partition-all 10 calc-measurements))]
+      (is (= {:logged false,
+              :batch `({:insert :partitioned_measurements, :values
+                        {:timestamp #inst "2014-01-01T00:01:00.000-00:00", :value "1",
+                         :reading_metadata {"is-number" "true", "median-spike" "n-a"},
+                         :device_id nil, :sensor_id "12345", :month nil}}
+                       {:insert :partitioned_measurements, :values
+                        {:timestamp #inst "2014-01-01T00:02:00.000-00:00", :value "1",
+                         :reading_metadata {"is-number" "true", "median-spike" "n-a"},
+                         :device_id nil, :sensor_id "12345", :month nil}}
+                       {:insert :partitioned_measurements, :values
+                        {:timestamp #inst "2014-01-01T00:03:00.000-00:00", :value "1",
+                         :reading_metadata {"is-number" "true", "median-spike" "n-a"},
+                         :device_id nil, :sensor_id "12345", :month nil}}
+                       {:insert :partitioned_measurements, :values
+                        {:timestamp #inst "2014-01-01T00:04:00.000-00:00", :value "1",
+                         :reading_metadata {"is-number" "true", "median-spike" "n-a"},
+                         :device_id nil, :sensor_id "12345", :month nil}}
+                       {:insert :partitioned_measurements, :values
+                        {:timestamp #inst "2014-01-01T00:05:00.000-00:00", :value "1",
+                         :reading_metadata {"is-number" "true", "median-spike" "n-a"},
+                         :device_id nil, :sensor_id "12345", :month nil}}
+                       {:insert :partitioned_measurements, :values
+                        {:timestamp #inst "2014-01-01T00:06:00.000-00:00", :value "1",
+                         :reading_metadata {"is-number" "true", "median-spike" "n-a"},
+                         :device_id nil, :sensor_id "12345", :month nil}}
+                       {:insert :partitioned_measurements, :values
+                        {:timestamp #inst "2014-01-01T00:07:00.000-00:00", :value "1",
+                         :reading_metadata {"is-number" "true", "median-spike" "n-a"},
+                         :device_id nil, :sensor_id "12345", :month nil}}
+                       {:insert :partitioned_measurements, :values
+                        {:timestamp #inst "2014-01-01T00:08:00.000-00:00", :value "1",
+                         :reading_metadata {"is-number" "true", "median-spike" "n-a"},
+                         :device_id nil, :sensor_id "12345", :month nil}}
+                       {:insert :partitioned_measurements, :values
+                        {:timestamp #inst "2014-01-01T00:09:00.000-00:00", :value "1",
+                         :reading_metadata {"is-number" "true", "median-spike" "n-a"},
+                         :device_id nil, :sensor_id "12345", :month nil}}
+                       {:insert :partitioned_measurements, :values
+                        {:timestamp #inst "2014-01-01T00:10:00.000-00:00", :value "1",
+                         :reading_metadata {"is-number" "true", "median-spike" "n-a"},
+                         :device_id nil, :sensor_id "12345", :month nil}})}
+             (prepare-batch batch-measurements)))
+      ;; Make sure there is a sensor_id
+      (is (not-any? empty?
+                    (map #(get-in % [:values :sensor_id]) 
+                         (:batch (prepare-batch batch-measurements))))))))
 
 (deftest where-test
   (testing "Testing conversion of a where clause map to hayt format."


### PR DESCRIPTION
PR for a new test. 

It makes sure the query for rollups to insert data into partitioned_measurement is formatted correctly and doesn't lead to an error
